### PR TITLE
feat: フィルター選択画面 (/filter)

### DIFF
--- a/src/app/filter/page.tsx
+++ b/src/app/filter/page.tsx
@@ -1,0 +1,20 @@
+import { FilterList } from '@/components/filter/filter-list'
+import { PageContainer } from '@/components/ui/page-container'
+import { ReceiptFrame } from '@/components/ui/receipt-frame'
+
+export default function FilterPage() {
+  return (
+    <PageContainer>
+      <ReceiptFrame className="mb-6 px-4 py-3" showTornEdge={false}>
+        <div className="receipt-text text-center">
+          <p className="text-xs text-ink-light tracking-widest">━━━━━━━━━━━━━━━━━━</p>
+          <p className="mt-1 text-lg font-bold">フィルターを選ぼう</p>
+          <p className="text-xs text-ink-light">好きなフィルターをタップしてね</p>
+          <p className="mt-1 text-xs text-ink-light tracking-widest">━━━━━━━━━━━━━━━━━━</p>
+        </div>
+      </ReceiptFrame>
+
+      <FilterList />
+    </PageContainer>
+  )
+}

--- a/src/components/filter/filter-card.tsx
+++ b/src/components/filter/filter-card.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import type { FilterInfo } from '@/lib/filters'
+
+type FilterCardProps = {
+  readonly filter: FilterInfo
+  readonly isSelected: boolean
+  readonly onSelect: () => void
+}
+
+export function FilterCard({ filter, isSelected, onSelect }: FilterCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={[
+        'flex w-full items-center gap-3 rounded-2xl border-2 p-3 text-left',
+        'transition-all duration-150',
+        isSelected
+          ? 'border-pink bg-pink/5 shadow-[0_2px_8px_rgba(255,107,157,0.2)]'
+          : 'border-cream-dark bg-cream hover:border-pink-light',
+      ].join(' ')}
+    >
+      <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-cream-dark text-2xl">
+        {filter.emoji}
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="font-bold text-ink">{filter.name}</span>
+          {filter.type === 'ai' && (
+            <span className="rounded-full bg-yellow/20 px-2 py-0.5 text-[10px] font-bold text-ink">
+              AI
+            </span>
+          )}
+        </div>
+        <p className="mt-0.5 text-xs text-ink-light">{filter.description}</p>
+      </div>
+
+      {filter.type === 'ai' && (
+        <span className="shrink-0 font-mono text-[10px] text-ink-light">{filter.processingTime}</span>
+      )}
+    </button>
+  )
+}

--- a/src/components/filter/filter-list.tsx
+++ b/src/components/filter/filter-list.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useCallback } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { AI_FILTERS, type FilterId, type FilterInfo, SIMPLE_FILTERS } from '@/lib/filters'
+import { useSessionStore } from '@/stores/session-store'
+
+import { FilterCard } from './filter-card'
+
+export function FilterList() {
+  const router = useRouter()
+  const { filter, setFilter } = useSessionStore()
+
+  const handleSelect = useCallback(
+    (filterInfo: FilterInfo) => {
+      setFilter({ type: filterInfo.type, value: filterInfo.id })
+    },
+    [setFilter],
+  )
+
+  const handleStart = useCallback(() => {
+    if (!filter) return
+    router.push('/shoot')
+  }, [filter, router])
+
+  const selectedId: FilterId | null = filter?.value ?? null
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section>
+        <h2 className="mb-3 font-bold text-ink">
+          <span className="receipt-text text-xs text-ink-light">━━</span> 簡易フィルター
+        </h2>
+        <div className="flex flex-col gap-2">
+          {SIMPLE_FILTERS.map((f) => (
+            <FilterCard
+              key={f.id}
+              filter={f}
+              isSelected={selectedId === f.id}
+              onSelect={() => handleSelect(f)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-3 font-bold text-ink">
+          <span className="receipt-text text-xs text-ink-light">━━</span> AIスタイル変換
+        </h2>
+        <p className="mb-3 rounded-xl bg-yellow/10 p-2 text-xs text-ink-light">
+          AIが画風を変換するため、処理に15秒ほどかかります
+        </p>
+        <div className="flex flex-col gap-2">
+          {AI_FILTERS.map((f) => (
+            <FilterCard
+              key={f.id}
+              filter={f}
+              isSelected={selectedId === f.id}
+              onSelect={() => handleSelect(f)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <div className="sticky bottom-4 pt-2">
+        <Button size="lg" className="w-full" disabled={!filter} onClick={handleStart}>
+          {filter ? '撮影スタート →' : 'フィルターを選んでね'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/filters.ts
+++ b/src/lib/filters.ts
@@ -1,0 +1,84 @@
+export type SimpleFilterId = 'natural' | 'skin-smooth' | 'brightness' | 'monochrome' | 'sepia'
+export type AiFilterId = 'anime' | 'pop-art' | 'watercolor'
+export type FilterId = SimpleFilterId | AiFilterId
+
+export type FilterInfo = {
+  readonly id: FilterId
+  readonly name: string
+  readonly description: string
+  readonly type: 'simple' | 'ai'
+  readonly emoji: string
+  readonly processingTime: string
+}
+
+export const SIMPLE_FILTERS: readonly FilterInfo[] = [
+  {
+    id: 'natural',
+    name: 'ナチュラル',
+    description: 'そのまま、ありのままで',
+    type: 'simple',
+    emoji: '✨',
+    processingTime: '即座',
+  },
+  {
+    id: 'skin-smooth',
+    name: '美肌',
+    description: 'つるすべ肌に補正',
+    type: 'simple',
+    emoji: '🍑',
+    processingTime: '~1秒',
+  },
+  {
+    id: 'brightness',
+    name: '明るさ補正',
+    description: 'パッと明るく映える',
+    type: 'simple',
+    emoji: '☀️',
+    processingTime: '~1秒',
+  },
+  {
+    id: 'monochrome',
+    name: 'モノクロ',
+    description: 'レシートとの相性バツグン',
+    type: 'simple',
+    emoji: '🖤',
+    processingTime: '~1秒',
+  },
+  {
+    id: 'sepia',
+    name: 'セピア',
+    description: 'エモいレトロ感',
+    type: 'simple',
+    emoji: '📷',
+    processingTime: '~1秒',
+  },
+] as const
+
+export const AI_FILTERS: readonly FilterInfo[] = [
+  {
+    id: 'anime',
+    name: 'アニメ風',
+    description: 'AIがイラスト風に変換',
+    type: 'ai',
+    emoji: '🎨',
+    processingTime: '~15秒',
+  },
+  {
+    id: 'pop-art',
+    name: 'ポップアート',
+    description: 'カラフルでポップに',
+    type: 'ai',
+    emoji: '🎪',
+    processingTime: '~15秒',
+  },
+  {
+    id: 'watercolor',
+    name: '水彩画',
+    description: 'やわらかい水彩タッチ',
+    type: 'ai',
+    emoji: '🌊',
+    processingTime: '~15秒',
+  },
+] as const
+
+export const ALL_FILTERS: readonly FilterInfo[] = [...SIMPLE_FILTERS, ...AI_FILTERS]


### PR DESCRIPTION
## Summary
- フィルター選択画面の実装（`/filter` ルート）
- 簡易フィルター5種 + AIスタイル変換3種のカード型UIを提供
- プリクラアプリ風の丸いアイコン + カード選択UI
- Zustand sessionStore と連携してフィルター選択状態を管理
- AIフィルター選択時は処理時間の注意表示

## 画面構成
- レシート風ヘッダー（「フィルターを選ぼう」）
- 簡易フィルターセクション（5つ）
- AIスタイル変換セクション（3つ + 処理時間注意）
- sticky な「撮影スタート」ボタン（フィルター未選択時はdisabled）

## Test plan
- [x] `npm run build` パス
- [x] `npm run type-check` パス
- [x] `npm run lint` パス
- [ ] `/filter` にアクセスしてフィルター選択UI確認
- [ ] フィルター選択→「撮影スタート」ボタンのenabled切替確認