### PR TITLE
refactor: AI感の排除 - UI全面リデザイン

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+screenshots/

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hackz-megalo-front",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^0.577.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -4885,6 +4886,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "lucide-react": "^0.577.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/src/app/filter/page.tsx
+++ b/src/app/filter/page.tsx
@@ -1,18 +1,13 @@
 import { FilterList } from '@/components/filter/filter-list'
 import { PageContainer } from '@/components/ui/page-container'
-import { ReceiptFrame } from '@/components/ui/receipt-frame'
 
 export default function FilterPage() {
   return (
     <PageContainer>
-      <ReceiptFrame className="mb-6 px-4 py-3" showTornEdge={false}>
-        <div className="receipt-text text-center">
-          <p className="text-xs text-ink-light tracking-widest">━━━━━━━━━━━━━━━━━━</p>
-          <p className="mt-1 text-lg font-bold">フィルターを選ぼう</p>
-          <p className="text-xs text-ink-light">好きなフィルターをタップしてね</p>
-          <p className="mt-1 text-xs text-ink-light tracking-widest">━━━━━━━━━━━━━━━━━━</p>
-        </div>
-      </ReceiptFrame>
+      <header className="mb-8">
+        <p className="receipt-text text-[10px] tracking-[0.3em] text-ink-light">STEP 01</p>
+        <h1 className="mt-1 text-xl font-bold tracking-tight">フィルターを選ぼう</h1>
+      </header>
 
       <FilterList />
     </PageContainer>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,27 +1,22 @@
 @import 'tailwindcss';
 
 @theme inline {
-  /* ── カラーパレット: 感熱紙ポップ ── */
-  --color-cream: #fff8f0;
-  --color-cream-dark: #f0e6d6;
-  --color-ink: #2d2d2d;
-  --color-ink-light: #5a5a5a;
-  --color-pink: #ff6b9d;
-  --color-pink-light: #ff9bbe;
-  --color-pink-dark: #e8527e;
-  --color-yellow: #ffd93d;
-  --color-yellow-light: #ffe680;
-  --color-mint: #26de81;
-  --color-red: #ff4757;
-  --color-lavender: #c8a2f8;
+  --color-cream: #fefcf8;
+  --color-cream-dark: #ebe5da;
+  --color-ink: #1a1a1a;
+  --color-ink-light: #6b6b6b;
+  --color-pink: #e05280;
+  --color-pink-light: #f0a0b8;
+  --color-pink-dark: #c03060;
+  --color-yellow: #d4a520;
+  --color-mint: #2aaa6a;
+  --color-red: #cc3333;
 
-  /* ── フォント ── */
   --font-sans: var(--font-zen-maru), 'Hiragino Maru Gothic Pro', 'BIZ UDGothic', sans-serif;
   --font-mono: var(--font-ibm-mono), 'Courier New', monospace;
   --font-display: var(--font-dela-gothic), sans-serif;
 }
 
-/* ── ベーススタイル ── */
 html {
   background-color: var(--color-cream);
   color: var(--color-ink);
@@ -32,49 +27,33 @@ body {
   min-height: 100dvh;
 }
 
-/* ── レシート紙テクスチャ ── */
+/* レシート紙テクスチャ */
 .receipt-texture {
-  background-color: var(--color-cream);
-  background-image: url("data:image/svg+xml,%3Csvg width='4' height='4' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='4' height='4' fill='%23fff8f0'/%3E%3Crect width='1' height='1' x='1' y='1' fill='%23f5ead8' fill-opacity='0.4'/%3E%3C/svg%3E");
+  background-color: #fefefe;
+  background-image: url("data:image/svg+xml,%3Csvg width='6' height='6' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='6' height='6' fill='%23fefefe'/%3E%3Ccircle cx='3' cy='3' r='0.5' fill='%23e8e0d0' fill-opacity='0.3'/%3E%3C/svg%3E");
 }
 
-/* ── レシート千切れた端 ── */
+/* レシート千切れた端 */
 .receipt-torn-edge {
-  --tear-color: var(--color-cream);
+  --tear-color: #fefefe;
   position: relative;
 }
 
 .receipt-torn-edge::after {
   content: '';
   position: absolute;
-  bottom: -12px;
+  bottom: -10px;
   left: 0;
   right: 0;
-  height: 12px;
-  background: linear-gradient(
-      135deg,
-      var(--tear-color) 33.33%,
-      transparent 33.33%
-    )
-    0 0 / 12px 100%,
-    linear-gradient(
-      -135deg,
-      var(--tear-color) 33.33%,
-      transparent 33.33%
-    )
-    0 0 / 12px 100%;
+  height: 10px;
+  background:
+    linear-gradient(135deg, var(--tear-color) 33.33%, transparent 33.33%) 0 0 / 10px 100%,
+    linear-gradient(-135deg, var(--tear-color) 33.33%, transparent 33.33%) 0 0 / 10px 100%;
 }
 
-/* ── ぷっくりテキスト ── */
-.pukkuri-text {
-  text-shadow:
-    1px 1px 0 var(--color-pink-light),
-    2px 2px 0 rgba(255, 107, 157, 0.3);
-}
-
-/* ── モノスペース レシート風テキスト ── */
+/* モノスペース レシート風テキスト */
 .receipt-text {
   font-family: var(--font-mono);
-  letter-spacing: 0.05em;
-  line-height: 1.8;
+  letter-spacing: 0.04em;
+  line-height: 1.7;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,26 +2,66 @@ import Link from 'next/link'
 
 import { Button } from '@/components/ui/button'
 import { PageContainer } from '@/components/ui/page-container'
-import { ReceiptFrame } from '@/components/ui/receipt-frame'
 
 export default function Home() {
   return (
-    <PageContainer className="flex flex-col items-center justify-center gap-8">
-      <h1 className="pukkuri-text font-display text-4xl text-pink">Receipt Purikura</h1>
+    <PageContainer className="flex flex-col items-center justify-center gap-0">
+      {/* レシート風ヘッダー */}
+      <div className="receipt-texture w-full max-w-xs border border-cream-dark px-5 pb-8 pt-6 shadow-sm">
+        <div className="receipt-text text-center text-ink">
+          <p className="text-[10px] tracking-[0.3em] text-ink-light">*** RECEIPT ***</p>
+          <div className="my-3 border-t border-dashed border-ink-light/30" />
 
-      <ReceiptFrame className="w-full p-6">
-        <div className="receipt-text text-center">
-          <p className="text-ink-light text-xs tracking-widest">━━━━━━━━━━━━━━━━━━</p>
-          <p className="mt-3 text-lg font-bold">レシートプリクラ</p>
-          <p className="mt-1 text-sm text-ink-light">サーマルプリンターで印刷する</p>
-          <p className="text-sm text-ink-light">レトロなプリクラ体験</p>
-          <p className="mt-3 text-ink-light text-xs tracking-widest">━━━━━━━━━━━━━━━━━━</p>
+          <p className="text-base font-bold tracking-wide">レシートプリクラ</p>
+          <p className="mt-0.5 text-[10px] text-ink-light">RECEIPT PURIKURA</p>
+
+          <div className="my-3 border-t border-dashed border-ink-light/30" />
+
+          <p className="text-left text-xs leading-relaxed">
+            サーマルプリンターで印刷する
+            <br />
+            レトロなプリクラ体験
+          </p>
+
+          <div className="my-3 border-t border-dashed border-ink-light/30" />
+
+          <table className="w-full text-left text-[10px]">
+            <tbody>
+              <tr>
+                <td className="py-0.5 text-ink-light">フィルター</td>
+                <td className="py-0.5 text-right">8種類</td>
+              </tr>
+              <tr>
+                <td className="py-0.5 text-ink-light">撮影枚数</td>
+                <td className="py-0.5 text-right">4枚</td>
+              </tr>
+              <tr>
+                <td className="py-0.5 text-ink-light">処理時間</td>
+                <td className="py-0.5 text-right">~30秒</td>
+              </tr>
+              <tr>
+                <td className="py-0.5 text-ink-light">お値段</td>
+                <td className="py-0.5 text-right font-bold">¥0</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div className="my-3 border-t border-dashed border-ink-light/30" />
+
+          <p className="text-[10px] text-ink-light">毎度ありがとうございます</p>
         </div>
-      </ReceiptFrame>
 
-      <Link href="/filter">
-        <Button size="lg">撮影スタート</Button>
-      </Link>
+        {/* 千切れた端 */}
+        <div className="receipt-torn-edge" />
+      </div>
+
+      <div className="mt-10 w-full max-w-xs">
+        <Link href="/filter">
+          <Button size="lg" className="w-full">
+            撮影スタート
+          </Button>
+        </Link>
+      </div>
     </PageContainer>
   )
 }

--- a/src/components/filter/filter-card.tsx
+++ b/src/components/filter/filter-card.tsx
@@ -14,31 +14,34 @@ export function FilterCard({ filter, isSelected, onSelect }: FilterCardProps) {
       type="button"
       onClick={onSelect}
       className={[
-        'flex w-full items-center gap-3 rounded-2xl border-2 p-3 text-left',
-        'transition-all duration-150',
+        'group flex items-center gap-3 rounded-sm border-l-4 px-3 py-2.5 text-left',
+        'transition-all duration-100',
         isSelected
-          ? 'border-pink bg-pink/5 shadow-[0_2px_8px_rgba(255,107,157,0.2)]'
-          : 'border-cream-dark bg-cream hover:border-pink-light',
+          ? 'border-l-ink bg-cream-dark/60'
+          : 'border-l-transparent hover:border-l-cream-dark hover:bg-cream-dark/30',
       ].join(' ')}
+      style={isSelected ? { borderLeftColor: filter.color } : undefined}
     >
-      <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-cream-dark text-2xl">
-        {filter.emoji}
-      </span>
+      {/* カラースウォッチ */}
+      <div
+        className={[
+          'h-8 w-8 shrink-0 rounded-full border',
+          'transition-transform duration-100',
+          isSelected ? 'scale-110 border-ink' : 'border-cream-dark group-hover:scale-105',
+          filter.id === 'monochrome' ? 'border-ink-light' : '',
+        ].join(' ')}
+        style={{ backgroundColor: filter.color }}
+      />
 
       <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="font-bold text-ink">{filter.name}</span>
-          {filter.type === 'ai' && (
-            <span className="rounded-full bg-yellow/20 px-2 py-0.5 text-[10px] font-bold text-ink">
-              AI
-            </span>
-          )}
-        </div>
-        <p className="mt-0.5 text-xs text-ink-light">{filter.description}</p>
+        <span className={['text-sm', isSelected ? 'font-bold' : 'font-medium'].join(' ')}>
+          {filter.name}
+        </span>
+        <span className="ml-2 text-xs text-ink-light">{filter.description}</span>
       </div>
 
       {filter.type === 'ai' && (
-        <span className="shrink-0 font-mono text-[10px] text-ink-light">{filter.processingTime}</span>
+        <span className="font-mono text-[10px] text-ink-light">{filter.processingTime}</span>
       )}
     </button>
   )

--- a/src/components/filter/filter-list.tsx
+++ b/src/components/filter/filter-list.tsx
@@ -28,12 +28,11 @@ export function FilterList() {
   const selectedId: FilterId | null = filter?.value ?? null
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-8">
       <section>
-        <h2 className="mb-3 font-bold text-ink">
-          <span className="receipt-text text-xs text-ink-light">━━</span> 簡易フィルター
-        </h2>
-        <div className="flex flex-col gap-2">
+        <p className="receipt-text mb-1 text-[10px] tracking-[0.3em] text-ink-light">SIMPLE</p>
+        <h2 className="mb-3 text-sm font-bold">簡易フィルター</h2>
+        <div className="flex flex-col">
           {SIMPLE_FILTERS.map((f) => (
             <FilterCard
               key={f.id}
@@ -46,13 +45,12 @@ export function FilterList() {
       </section>
 
       <section>
-        <h2 className="mb-3 font-bold text-ink">
-          <span className="receipt-text text-xs text-ink-light">━━</span> AIスタイル変換
-        </h2>
-        <p className="mb-3 rounded-xl bg-yellow/10 p-2 text-xs text-ink-light">
-          AIが画風を変換するため、処理に15秒ほどかかります
+        <p className="receipt-text mb-1 text-[10px] tracking-[0.3em] text-ink-light">AI STYLE</p>
+        <h2 className="mb-2 text-sm font-bold">AIスタイル変換</h2>
+        <p className="mb-3 font-mono text-[10px] text-ink-light">
+          * 処理に15秒ほどかかります
         </p>
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col">
           {AI_FILTERS.map((f) => (
             <FilterCard
               key={f.id}
@@ -64,9 +62,9 @@ export function FilterList() {
         </div>
       </section>
 
-      <div className="sticky bottom-4 pt-2">
+      <div className="sticky bottom-4">
         <Button size="lg" className="w-full" disabled={!filter} onClick={handleStart}>
-          {filter ? '撮影スタート →' : 'フィルターを選んでね'}
+          {filter ? '撮影スタート' : 'フィルターを選んでね'}
         </Button>
       </div>
     </div>

--- a/src/components/preview/photo-grid.tsx
+++ b/src/components/preview/photo-grid.tsx
@@ -9,9 +9,9 @@ type PhotoGridProps = {
 
 export function PhotoGrid({ photos, onRetake }: PhotoGridProps) {
   return (
-    <div className="grid grid-cols-2 gap-2">
+    <div className="grid grid-cols-2 gap-1.5">
       {photos.map((photo, index) => (
-        <div key={index} className="group relative aspect-[3/4] overflow-hidden rounded-lg border-2 border-cream-dark">
+        <div key={index} className="group relative aspect-[3/4] overflow-hidden border border-cream-dark">
           <Image
             src={photo}
             alt={`撮影${index + 1}枚目`}
@@ -20,17 +20,17 @@ export function PhotoGrid({ photos, onRetake }: PhotoGridProps) {
             unoptimized
           />
 
-          <div className="absolute inset-0 flex items-end justify-center bg-gradient-to-t from-ink/40 to-transparent opacity-0 transition-opacity group-hover:opacity-100 group-active:opacity-100">
+          <div className="absolute inset-0 flex items-end justify-center bg-gradient-to-t from-ink/30 to-transparent opacity-0 transition-opacity group-hover:opacity-100 group-active:opacity-100">
             <button
               type="button"
               onClick={() => onRetake(index)}
-              className="mb-2 rounded-full bg-cream px-3 py-1.5 text-xs font-bold text-ink shadow-md"
+              className="mb-2 bg-cream px-3 py-1 text-xs font-bold text-ink"
             >
               撮り直す
             </button>
           </div>
 
-          <span className="absolute top-1.5 left-1.5 flex h-6 w-6 items-center justify-center rounded-full bg-pink text-xs font-bold text-white">
+          <span className="absolute top-1 left-1 bg-ink/60 px-1.5 py-0.5 font-mono text-[10px] text-white">
             {index + 1}
           </span>
         </div>

--- a/src/components/preview/preview-view.tsx
+++ b/src/components/preview/preview-view.tsx
@@ -40,14 +40,11 @@ export function PreviewView() {
 
   return (
     <PageContainer className="flex flex-col gap-6">
-      <ReceiptFrame className="px-4 py-3" showTornEdge={false}>
-        <div className="receipt-text text-center">
-          <p className="text-xs text-ink-light tracking-widest">━━━━━━━━━━━━━━━━━━</p>
-          <p className="mt-1 text-lg font-bold">プレビュー</p>
-          <p className="text-xs text-ink-light">タップで撮り直しできるよ</p>
-          <p className="mt-1 text-xs text-ink-light tracking-widest">━━━━━━━━━━━━━━━━━━</p>
-        </div>
-      </ReceiptFrame>
+      <header>
+        <p className="receipt-text text-[10px] tracking-[0.3em] text-ink-light">STEP 03</p>
+        <h1 className="mt-1 text-xl font-bold tracking-tight">プレビュー</h1>
+        <p className="mt-0.5 text-xs text-ink-light">タップで撮り直しできるよ</p>
+      </header>
 
       <ReceiptFrame className="p-3">
         <PhotoGrid photos={photos} onRetake={handleRetake} />
@@ -55,7 +52,7 @@ export function PreviewView() {
 
       <div className="flex flex-col gap-3">
         <Button size="lg" className="w-full" onClick={handleConfirm}>
-          OK! 印刷する 🖨️
+          OK! 印刷する
         </Button>
 
         <Button variant="secondary" size="md" className="w-full" onClick={handleRetakeAll}>
@@ -63,8 +60,8 @@ export function PreviewView() {
         </Button>
       </div>
 
-      <p className="receipt-text text-center text-xs text-ink-light">
-        フィルター: {filter?.value ?? '未選択'}
+      <p className="receipt-text text-center font-mono text-[10px] text-ink-light">
+        FILTER: {filter?.value ?? 'none'}
       </p>
     </PageContainer>
   )

--- a/src/components/processing/processing-view.tsx
+++ b/src/components/processing/processing-view.tsx
@@ -50,24 +50,21 @@ export function ProcessingView({ sessionId }: ProcessingViewProps) {
     <PageContainer className="flex flex-col items-center justify-center gap-8">
       <ReceiptPrinterAnimation />
 
-      <ReceiptFrame className="w-full p-5">
-        <div className="receipt-text text-center">
-          <p className="text-xs text-ink-light tracking-widest">━━━━━━━━━━━━━━━━━━</p>
-          <p className="mt-2 text-sm font-bold">処理中...</p>
-          <p className="mb-2 text-xs text-ink-light">レシートを準備しています</p>
-          <p className="text-xs text-ink-light tracking-widest">━━━━━━━━━━━━━━━━━━</p>
+      <ReceiptFrame className="w-full px-5 py-5">
+        <div className="receipt-text text-center text-ink">
+          <p className="text-[10px] tracking-[0.3em] text-ink-light">*** PROCESSING ***</p>
+          <div className="my-2 border-t border-dashed border-ink-light/30" />
+          <p className="text-xs font-bold">処理中</p>
+          <p className="text-[10px] text-ink-light">レシートを準備しています</p>
+          <div className="my-2 border-t border-dashed border-ink-light/30" />
         </div>
 
-        <div className="mt-4 border-t border-dashed border-cream-dark pt-4">
-          <ProcessingSteps currentStep={processingStep ?? 'uploading'} />
-        </div>
+        <ProcessingSteps currentStep={processingStep ?? 'uploading'} />
 
-        <div className="mt-4 border-t border-dashed border-cream-dark pt-3 text-center">
-          <p className="font-mono text-[10px] text-ink-light">SESSION: {sessionId}</p>
+        <div className="mt-3 border-t border-dashed border-ink-light/30 pt-2 text-center">
+          <p className="font-mono text-[10px] text-ink-light">No. {sessionId}</p>
         </div>
       </ReceiptFrame>
-
-      <p className="animate-pulse text-sm text-ink-light">しばらくお待ちください...</p>
     </PageContainer>
   )
 }

--- a/src/components/result/download-view.tsx
+++ b/src/components/result/download-view.tsx
@@ -16,43 +16,37 @@ export function DownloadView({ sessionId }: DownloadViewProps) {
 
   return (
     <PageContainer className="flex flex-col items-center justify-center gap-6">
-      <ReceiptFrame className="w-full p-5">
-        <div className="receipt-text text-center">
-          <p className="text-xs text-ink-light tracking-widest">━━━━━━━━━━━━━━━━━━</p>
-          <p className="mt-2 text-lg font-bold">カラー版ダウンロード</p>
-          <p className="text-xs text-ink-light">レシートのQRコードからアクセスしました</p>
-          <p className="mt-2 text-xs text-ink-light tracking-widest">━━━━━━━━━━━━━━━━━━</p>
+      <ReceiptFrame className="w-full px-5 py-5">
+        <div className="receipt-text text-center text-ink">
+          <p className="text-[10px] tracking-[0.3em] text-ink-light">*** DOWNLOAD ***</p>
+          <div className="my-2 border-t border-dashed border-ink-light/30" />
+          <p className="text-xs font-bold">カラー版ダウンロード</p>
+          <p className="font-mono text-[10px] text-ink-light">No. {sessionId}</p>
+          <div className="my-2 border-t border-dashed border-ink-light/30" />
         </div>
 
-        <div className="mt-4 border-t border-dashed border-cream-dark pt-4">
-          <div className="relative mx-auto aspect-square max-w-xs rounded-lg border-2 border-dashed border-cream-dark bg-cream-dark/30">
-            {downloadUrl ? (
-              <Image
-                src={downloadUrl}
-                alt="カラー版コラージュ"
-                fill
-                className="rounded-lg object-cover"
-                unoptimized
-              />
-            ) : (
-              <div className="flex h-full items-center justify-center text-ink-light">
-                <div className="text-center">
-                  <p className="text-4xl">🎨</p>
-                  <p className="mt-2 text-xs">カラー版コラージュ</p>
-                  <p className="text-[10px]">(バックエンド接続後に表示)</p>
-                </div>
+        <div className="relative mx-auto aspect-square max-w-xs border border-dashed border-ink-light/30 bg-cream-dark/20">
+          {downloadUrl ? (
+            <Image
+              src={downloadUrl}
+              alt="カラー版コラージュ"
+              fill
+              className="object-cover"
+              unoptimized
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              <div className="receipt-text text-center text-ink-light">
+                <p className="text-xs">[ カラー版コラージュ ]</p>
+                <p className="mt-1 text-[10px]">バックエンド接続後に表示</p>
               </div>
-            )}
-          </div>
-        </div>
-
-        <div className="mt-4 text-center">
-          <p className="font-mono text-[10px] text-ink-light">SESSION: {sessionId}</p>
+            </div>
+          )}
         </div>
       </ReceiptFrame>
 
       <Button size="lg" className="w-full" disabled={!downloadUrl}>
-        高解像度で保存する
+        高解像度で保存
       </Button>
     </PageContainer>
   )

--- a/src/components/result/result-view.tsx
+++ b/src/components/result/result-view.tsx
@@ -13,64 +13,61 @@ type ResultViewProps = {
 
 export function ResultView({ sessionId }: ResultViewProps) {
   // TODO: sessionId でバックエンドから結果を取得
-  // 現在はデモ用プレースホルダー
   const collageUrl: string | null = null
   const caption = 'みんなの笑顔が最高にキュートだね！'
 
   return (
     <PageContainer className="flex flex-col items-center gap-6">
-      <h1 className="pukkuri-text font-display text-2xl text-pink">できた！</h1>
+      <header>
+        <p className="receipt-text text-[10px] tracking-[0.3em] text-ink-light">COMPLETE</p>
+        <h1 className="mt-1 text-xl font-bold tracking-tight">できた！</h1>
+      </header>
 
-      <ReceiptFrame className="w-full overflow-hidden">
-        <div className="receipt-text px-4 pt-3 text-center">
-          <p className="text-xs text-ink-light tracking-widest">━━━━━━━━━━━━━━━━━━</p>
-          <p className="mt-1 text-sm font-bold">RECEIPT PURIKURA</p>
-          <p className="text-[10px] text-ink-light">SESSION: {sessionId}</p>
-          <p className="mt-1 text-xs text-ink-light tracking-widest">━━━━━━━━━━━━━━━━━━</p>
+      <ReceiptFrame className="w-full overflow-hidden px-5 py-5">
+        <div className="receipt-text text-center text-ink">
+          <p className="text-[10px] tracking-[0.3em] text-ink-light">*** RESULT ***</p>
+          <div className="my-2 border-t border-dashed border-ink-light/30" />
+          <p className="text-xs font-bold">RECEIPT PURIKURA</p>
+          <p className="font-mono text-[10px] text-ink-light">No. {sessionId}</p>
+          <div className="my-2 border-t border-dashed border-ink-light/30" />
         </div>
 
         {/* コラージュ画像 */}
-        <div className="relative mx-4 mt-3 aspect-square rounded-lg border-2 border-dashed border-cream-dark bg-cream-dark/30">
+        <div className="relative aspect-square border border-dashed border-ink-light/30 bg-cream-dark/20">
           {collageUrl ? (
             <Image
               src={collageUrl}
               alt="コラージュ"
               fill
-              className="rounded-lg object-cover"
+              className="object-cover"
               unoptimized
             />
           ) : (
-            <div className="flex h-full items-center justify-center text-ink-light">
-              <div className="text-center">
-                <p className="text-4xl">🖼️</p>
-                <p className="mt-2 text-xs">コラージュ画像</p>
-                <p className="text-[10px]">(バックエンド接続後に表示)</p>
+            <div className="flex h-full items-center justify-center">
+              <div className="receipt-text text-center text-ink-light">
+                <p className="text-xs">[ コラージュ画像 ]</p>
+                <p className="mt-1 text-[10px]">バックエンド接続後に表示</p>
               </div>
             </div>
           )}
         </div>
 
         {/* AIキャプション */}
-        <div className="mx-4 mt-3 rounded-xl bg-pink/5 p-3">
-          <p className="text-center text-sm font-bold text-ink">
-            <span className="text-pink">AI</span> &quot;{caption}&quot;
-          </p>
+        <div className="mt-3 border-t border-dashed border-ink-light/30 pt-3">
+          <p className="receipt-text text-xs text-ink-light">CAPTION:</p>
+          <p className="mt-1 text-sm leading-relaxed">&quot;{caption}&quot;</p>
         </div>
 
-        <div className="px-4 pb-3 pt-3 text-center">
-          <p className="receipt-text text-xs text-ink-light tracking-widest">━━━━━━━━━━━━━━━━━━</p>
-          <p className="mt-1 font-mono text-[10px] text-ink-light">
-            レシートのQRコードから
-          </p>
+        <div className="mt-3 border-t border-dashed border-ink-light/30 pt-2 text-center">
           <p className="font-mono text-[10px] text-ink-light">
-            カラー版をダウンロードできます
+            レシートのQRからカラー版DL可
           </p>
         </div>
       </ReceiptFrame>
 
       <div className="flex w-full flex-col gap-3">
         <Button size="lg" className="w-full" disabled={!collageUrl}>
-          画像を保存する
+          画像を保存
         </Button>
 
         <Link href="/filter" className="w-full">

--- a/src/components/shoot/countdown-overlay.tsx
+++ b/src/components/shoot/countdown-overlay.tsx
@@ -9,7 +9,7 @@ export function CountdownOverlay({ count }: CountdownOverlayProps) {
 
   return (
     <div className="absolute inset-0 z-10 flex items-center justify-center">
-      <div className="pukkuri-text animate-bounce font-display text-[120px] text-white drop-shadow-[0_4px_8px_rgba(0,0,0,0.4)]">
+      <div className="font-mono text-[120px] font-bold text-white drop-shadow-[0_2px_4px_rgba(0,0,0,0.5)]">
         {count}
       </div>
     </div>

--- a/src/components/shoot/shoot-view.tsx
+++ b/src/components/shoot/shoot-view.tsx
@@ -53,15 +53,14 @@ export function ShootView() {
 
   if (error) {
     return (
-      <div className="flex min-h-dvh flex-col items-center justify-center gap-4 px-6 text-center">
-        <p className="text-4xl">📷</p>
-        <p className="font-bold text-red">{error}</p>
+      <div className="flex min-h-dvh flex-col items-center justify-center gap-4 bg-cream px-6 text-center">
+        <p className="receipt-text text-sm font-bold text-red">{error}</p>
         <button
           type="button"
-          className="text-sm text-pink underline"
+          className="text-sm text-ink-light underline"
           onClick={() => router.replace('/filter')}
         >
-          フィルター選択に戻る
+          戻る
         </button>
       </div>
     )
@@ -93,14 +92,14 @@ export function ShootView() {
           <button
             type="button"
             onClick={shootSequence}
-            className="flex h-16 w-16 items-center justify-center rounded-full border-4 border-white bg-pink shadow-[0_0_20px_rgba(255,107,157,0.5)] transition-transform active:scale-90"
+            className="flex h-16 w-16 items-center justify-center rounded-full border-4 border-white/90 bg-white/20 transition-transform active:scale-90"
           >
             <div className="h-12 w-12 rounded-full bg-white" />
           </button>
         )}
 
         {isRunning && (
-          <p className="animate-pulse font-bold text-pink-light">撮影中...</p>
+          <p className="animate-pulse font-mono text-sm text-white/60">撮影中...</p>
         )}
       </div>
     </div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,24 +13,24 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 
 const variantStyles: Record<ButtonVariant, string> = {
   primary: [
-    'bg-pink text-white',
-    'shadow-[0_4px_0_0_theme(--color-pink-dark)]',
-    'hover:brightness-105',
-    'active:translate-y-[2px] active:shadow-[0_2px_0_0_theme(--color-pink-dark)]',
+    'bg-ink text-cream',
+    'shadow-[0_3px_0_0_#1a1a1a]',
+    'hover:bg-ink-light',
+    'active:translate-y-[2px] active:shadow-[0_1px_0_0_#1a1a1a]',
   ].join(' '),
   secondary: [
-    'bg-cream border-2 border-ink text-ink',
-    'shadow-[0_4px_0_0_theme(--color-ink)]',
+    'bg-cream border border-ink text-ink',
+    'shadow-[0_3px_0_0_theme(--color-cream-dark)]',
     'hover:bg-cream-dark',
-    'active:translate-y-[2px] active:shadow-[0_2px_0_0_theme(--color-ink)]',
+    'active:translate-y-[2px] active:shadow-[0_1px_0_0_theme(--color-cream-dark)]',
   ].join(' '),
   ghost: ['text-ink-light', 'hover:text-ink hover:bg-cream-dark'].join(' '),
 }
 
 const sizeStyles: Record<ButtonSize, string> = {
-  sm: 'px-4 py-2 text-sm',
-  md: 'px-6 py-3 text-base',
-  lg: 'px-8 py-4 text-lg',
+  sm: 'px-4 py-2 text-xs',
+  md: 'px-5 py-2.5 text-sm',
+  lg: 'px-6 py-3 text-base',
 }
 
 export function Button({
@@ -44,9 +44,9 @@ export function Button({
     <button
       className={[
         'inline-flex items-center justify-center',
-        'rounded-xl font-bold',
-        'transition-all duration-100',
-        'disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-y-0',
+        'rounded-sm font-bold tracking-wide',
+        'transition-all duration-75',
+        'disabled:opacity-40 disabled:cursor-not-allowed disabled:translate-y-0',
         variantStyles[variant],
         sizeStyles[size],
         className,

--- a/src/components/ui/receipt-frame.tsx
+++ b/src/components/ui/receipt-frame.tsx
@@ -15,7 +15,7 @@ export function ReceiptFrame({
 }: ReceiptFrameProps) {
   return (
     <div
-      className={`receipt-texture rounded-sm border border-cream-dark shadow-[2px_4px_12px_rgba(45,45,45,0.08)] ${showTornEdge ? 'receipt-torn-edge pb-6' : ''} ${className}`}
+      className={`receipt-texture border border-cream-dark shadow-sm ${showTornEdge ? 'receipt-torn-edge pb-6' : ''} ${className}`}
     >
       {children}
     </div>

--- a/src/components/ui/step-indicator.tsx
+++ b/src/components/ui/step-indicator.tsx
@@ -13,9 +13,8 @@ export function StepIndicator({ current, total, className = '' }: StepIndicatorP
         <div
           key={i}
           className={[
-            'h-3 w-3 rounded-full transition-all duration-200',
-            i < current ? 'bg-pink scale-100' : 'bg-cream-dark scale-90',
-            i === current - 1 ? 'ring-2 ring-pink-light ring-offset-2 ring-offset-cream' : '',
+            'h-2 w-2 rounded-full transition-all duration-200',
+            i < current ? 'bg-ink' : 'bg-cream-dark',
           ].join(' ')}
         />
       ))}

--- a/src/lib/filters.ts
+++ b/src/lib/filters.ts
@@ -7,7 +7,7 @@ export type FilterInfo = {
   readonly name: string
   readonly description: string
   readonly type: 'simple' | 'ai'
-  readonly emoji: string
+  readonly color: string
   readonly processingTime: string
 }
 
@@ -15,41 +15,41 @@ export const SIMPLE_FILTERS: readonly FilterInfo[] = [
   {
     id: 'natural',
     name: 'ナチュラル',
-    description: 'そのまま、ありのままで',
+    description: 'そのまま',
     type: 'simple',
-    emoji: '✨',
+    color: '#e8e4de',
     processingTime: '即座',
   },
   {
     id: 'skin-smooth',
     name: '美肌',
-    description: 'つるすべ肌に補正',
+    description: 'なめらか補正',
     type: 'simple',
-    emoji: '🍑',
+    color: '#f5cac3',
     processingTime: '~1秒',
   },
   {
     id: 'brightness',
-    name: '明るさ補正',
-    description: 'パッと明るく映える',
+    name: '明るさ',
+    description: '映える仕上がり',
     type: 'simple',
-    emoji: '☀️',
+    color: '#fde68a',
     processingTime: '~1秒',
   },
   {
     id: 'monochrome',
     name: 'モノクロ',
-    description: 'レシートとの相性バツグン',
+    description: 'レシート映え',
     type: 'simple',
-    emoji: '🖤',
+    color: '#404040',
     processingTime: '~1秒',
   },
   {
     id: 'sepia',
     name: 'セピア',
-    description: 'エモいレトロ感',
+    description: 'レトロ',
     type: 'simple',
-    emoji: '📷',
+    color: '#c4a882',
     processingTime: '~1秒',
   },
 ] as const
@@ -58,25 +58,25 @@ export const AI_FILTERS: readonly FilterInfo[] = [
   {
     id: 'anime',
     name: 'アニメ風',
-    description: 'AIがイラスト風に変換',
+    description: 'AIが変換',
     type: 'ai',
-    emoji: '🎨',
+    color: '#93c5fd',
     processingTime: '~15秒',
   },
   {
     id: 'pop-art',
     name: 'ポップアート',
-    description: 'カラフルでポップに',
+    description: 'カラフル',
     type: 'ai',
-    emoji: '🎪',
+    color: '#f472b6',
     processingTime: '~15秒',
   },
   {
     id: 'watercolor',
     name: '水彩画',
-    description: 'やわらかい水彩タッチ',
+    description: 'やわらか',
     type: 'ai',
-    emoji: '🌊',
+    color: '#6ee7b7',
     processingTime: '~15秒',
   },
 ] as const


### PR DESCRIPTION
## Summary
AI生成UIの典型パターンを全面的に排除

## 変更点
- 全画面から絵文字を完全排除（カラースウォッチ、テキスト、SVGに置換）
- `rounded-xl` → `rounded-sm` or 角丸なし（均一な角丸 = AI感）
- ピンク主体 → インク色主体（落ち着いた色味）
- `pukkuri-text`（ピンクtext-shadow）削除
- `━━━` セパレーター → `border-dashed`（本物のレシート）
- 各画面ヘッダーを STEP 01/02/03 形式に統一
- カラーパレットの彩度調整

## Test plan
- [x] `npm run build` パス
- [x] `npm run lint` パス
- [ ] ブラウザで全画面のデザイン確認