### PR TITLE
feat: ルームシステム + PC画面

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "lucide-react": "^0.577.0",
         "next": "16.1.6",
+        "qrcode.react": "^4.2.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "zustand": "^5.0.12"
@@ -5454,6 +5455,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "lucide-react": "^0.577.0",
     "next": "16.1.6",
+    "qrcode.react": "^4.2.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "zustand": "^5.0.12"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,6 @@ import { PageContainer } from '@/components/ui/page-container'
 export default function Home() {
   return (
     <PageContainer className="flex flex-col items-center justify-center gap-0">
-      {/* レシート風ヘッダー */}
       <div className="receipt-texture w-full max-w-xs border border-cream-dark px-5 pb-8 pt-6 shadow-sm">
         <div className="receipt-text text-center text-ink">
           <p className="text-[10px] tracking-[0.3em] text-ink-light">*** RECEIPT ***</p>
@@ -24,43 +23,24 @@ export default function Home() {
           </p>
 
           <div className="my-3 border-t border-dashed border-ink-light/30" />
-
-          <table className="w-full text-left text-[10px]">
-            <tbody>
-              <tr>
-                <td className="py-0.5 text-ink-light">フィルター</td>
-                <td className="py-0.5 text-right">8種類</td>
-              </tr>
-              <tr>
-                <td className="py-0.5 text-ink-light">撮影枚数</td>
-                <td className="py-0.5 text-right">4枚</td>
-              </tr>
-              <tr>
-                <td className="py-0.5 text-ink-light">処理時間</td>
-                <td className="py-0.5 text-right">~30秒</td>
-              </tr>
-              <tr>
-                <td className="py-0.5 text-ink-light">お値段</td>
-                <td className="py-0.5 text-right font-bold">¥0</td>
-              </tr>
-            </tbody>
-          </table>
-
-          <div className="my-3 border-t border-dashed border-ink-light/30" />
-
-          <p className="text-[10px] text-ink-light">毎度ありがとうございます</p>
+          <p className="text-[10px] text-ink-light">どちらのモードで参加しますか？</p>
         </div>
 
-        {/* 千切れた端 */}
         <div className="receipt-torn-edge" />
       </div>
 
-      <div className="mt-10 w-full max-w-xs">
-        <Link href="/filter">
+      <div className="mt-10 flex w-full max-w-xs flex-col gap-3">
+        <Link href="/pc">
           <Button size="lg" className="w-full">
-            撮影スタート
+            PCモード（大画面表示）
           </Button>
         </Link>
+
+        <p className="receipt-text text-center text-[10px] text-ink-light">or</p>
+
+        <p className="text-center text-xs text-ink-light">
+          スマホの方はPC画面のQRコードから参加してください
+        </p>
       </div>
     </PageContainer>
   )

--- a/src/app/pc/page.tsx
+++ b/src/app/pc/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { PcView } from '@/components/pc/pc-view'
+
+export default function PcPage() {
+  return <PcView />
+}

--- a/src/app/room/[roomId]/page.tsx
+++ b/src/app/room/[roomId]/page.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { use, useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+import { Button } from '@/components/ui/button'
+import { PageContainer } from '@/components/ui/page-container'
+import { useRoomStore } from '@/stores/room-store'
+
+type Props = {
+  readonly params: Promise<{ roomId: string }>
+}
+
+export default function RoomJoinPage({ params }: Props) {
+  const { roomId } = use(params)
+  const router = useRouter()
+  const { joinRoom } = useRoomStore()
+  // TODO: バックエンド接続後にエラー/満員状態を設定
+  const [status] = useState<'connecting' | 'error' | 'full'>('connecting')
+
+  useEffect(() => {
+    // TODO: バックエンドに接続してルームの存在確認 + 空き確認
+    // 現在はデモ用に即参加
+    const timer = setTimeout(() => {
+      joinRoom(roomId, 'phone')
+      router.replace('/filter')
+    }, 1000)
+
+    return () => clearTimeout(timer)
+  }, [roomId, joinRoom, router])
+
+  if (status === 'full') {
+    return (
+      <PageContainer className="flex flex-col items-center justify-center gap-4">
+        <p className="receipt-text text-sm font-bold text-red">このルームは満員です</p>
+        <p className="text-xs text-ink-light">1つのルームにつきスマホ1台まで</p>
+      </PageContainer>
+    )
+  }
+
+  if (status === 'error') {
+    return (
+      <PageContainer className="flex flex-col items-center justify-center gap-4">
+        <p className="receipt-text text-sm font-bold text-red">ルームが見つかりません</p>
+        <Button variant="secondary" size="sm" onClick={() => router.replace('/')}>
+          トップに戻る
+        </Button>
+      </PageContainer>
+    )
+  }
+
+  return (
+    <PageContainer className="flex flex-col items-center justify-center gap-4">
+      <div className="receipt-text text-center">
+        <p className="text-xs text-ink-light">ROOM: {roomId}</p>
+        <p className="mt-2 text-sm">接続中...</p>
+      </div>
+    </PageContainer>
+  )
+}

--- a/src/components/pc/complete-screen.tsx
+++ b/src/components/pc/complete-screen.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useEffect } from 'react'
+
+import { useRoomStore } from '@/stores/room-store'
+
+export function CompleteScreen() {
+  const { setPhase } = useRoomStore()
+
+  // 5秒後に自動で待機モードに戻る
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setPhase('idle')
+    }, 5000)
+
+    return () => clearTimeout(timer)
+  }, [setPhase])
+
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-ink px-8">
+      <div className="text-center">
+        <h2 className="text-3xl font-bold text-white">レシートを取ってね！</h2>
+        <p className="mt-4 font-mono text-sm text-white/40">5秒後に待機画面に戻ります...</p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/pc/filter-screen.tsx
+++ b/src/components/pc/filter-screen.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { ALL_FILTERS } from '@/lib/filters'
+import { useRoomStore } from '@/stores/room-store'
+
+export function FilterScreen() {
+  const { selectedFilter } = useRoomStore()
+
+  const current = ALL_FILTERS.find((f) => f.id === selectedFilter)
+
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-ink px-8">
+      <div className="text-center">
+        <p className="font-mono text-xs tracking-[0.3em] text-white/40">STEP 01</p>
+        <h2 className="mt-2 text-2xl font-bold text-white">フィルター選択中</h2>
+        <p className="mt-1 font-mono text-sm text-white/50">
+          スマホでフィルターを選んでいます...
+        </p>
+
+        {current && (
+          <div className="mt-8 flex flex-col items-center gap-3">
+            <div
+              className="h-20 w-20 rounded-full border-2 border-white/20"
+              style={{ backgroundColor: current.color }}
+            />
+            <p className="text-lg font-bold text-white">{current.name}</p>
+            <p className="text-sm text-white/50">{current.description}</p>
+          </div>
+        )}
+
+        {!current && (
+          <div className="mt-8">
+            <div className="mx-auto h-20 w-20 animate-pulse rounded-full border-2 border-dashed border-white/20" />
+            <p className="mt-3 text-sm text-white/30">未選択</p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/pc/idle-screen.tsx
+++ b/src/components/pc/idle-screen.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { QrDisplay } from './qr-display'
+
+type IdleScreenProps = {
+  readonly roomId: string
+}
+
+export function IdleScreen({ roomId }: IdleScreenProps) {
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-ink px-8">
+      <div className="flex flex-col items-center gap-8">
+        <header className="text-center">
+          <p className="font-mono text-xs tracking-[0.3em] text-white/40">*** RECEIPT PURIKURA ***</p>
+          <h1 className="mt-3 font-display text-4xl tracking-wide text-white">レシートプリクラ</h1>
+          <p className="mt-1 font-mono text-sm text-white/50">
+            サーマルプリンターで印刷するレトロなプリクラ体験
+          </p>
+        </header>
+
+        <QrDisplay roomId={roomId} />
+
+        <div className="receipt-text text-center text-white/30">
+          <p className="text-xs">スマホが接続されると撮影が始まります</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/pc/pc-view.tsx
+++ b/src/components/pc/pc-view.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect } from 'react'
+
+import { useRoomStore } from '@/stores/room-store'
+
+import { CompleteScreen } from './complete-screen'
+import { FilterScreen } from './filter-screen'
+import { IdleScreen } from './idle-screen'
+import { ProcessingScreen } from './processing-screen'
+import { ResultScreen } from './result-screen'
+import { ShootingScreen } from './shooting-screen'
+
+export function PcView() {
+  const { roomId, phase, createRoom } = useRoomStore()
+
+  useEffect(() => {
+    if (!roomId) {
+      createRoom()
+    }
+  }, [roomId, createRoom])
+
+  if (!roomId) return null
+
+  switch (phase) {
+    case 'idle':
+      return <IdleScreen roomId={roomId} />
+    case 'filter-select':
+      return <FilterScreen />
+    case 'shooting':
+    case 'preview':
+      return <ShootingScreen />
+    case 'processing':
+      return <ProcessingScreen />
+    case 'result':
+      return <ResultScreen />
+    case 'complete':
+      return <CompleteScreen />
+    default:
+      return <IdleScreen roomId={roomId} />
+  }
+}

--- a/src/components/pc/processing-screen.tsx
+++ b/src/components/pc/processing-screen.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { ProcessingSteps } from '@/components/processing/processing-steps'
+import { useSessionStore } from '@/stores/session-store'
+
+export function ProcessingScreen() {
+  const { processingStep } = useSessionStore()
+
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-ink px-8">
+      <div className="w-full max-w-sm">
+        <div className="text-center">
+          <p className="font-mono text-xs tracking-[0.3em] text-white/40">*** PROCESSING ***</p>
+          <h2 className="mt-2 text-2xl font-bold text-white">処理中</h2>
+        </div>
+
+        <div className="mt-8 border border-white/10 bg-white/5 px-6 py-5">
+          <ProcessingSteps currentStep={processingStep ?? 'uploading'} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/pc/qr-display.tsx
+++ b/src/components/pc/qr-display.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { QRCodeSVG } from 'qrcode.react'
+
+type QrDisplayProps = {
+  readonly roomId: string
+}
+
+export function QrDisplay({ roomId }: QrDisplayProps) {
+  const origin = typeof window !== 'undefined' ? window.location.origin : ''
+  const joinUrl = `${origin}/room/${roomId}`
+
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <div className="bg-white p-4">
+        <QRCodeSVG
+          value={joinUrl}
+          size={240}
+          level="M"
+          bgColor="#ffffff"
+          fgColor="#1a1a1a"
+        />
+      </div>
+
+      <div className="receipt-text text-center">
+        <p className="text-sm text-ink-light">スマホでスキャンして参加</p>
+        <p className="mt-1 font-mono text-xs text-ink-light">ROOM: {roomId}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/pc/result-screen.tsx
+++ b/src/components/pc/result-screen.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import Image from 'next/image'
+
+import { useSessionStore } from '@/stores/session-store'
+
+export function ResultScreen() {
+  const { collageUrl, caption } = useSessionStore()
+
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-ink px-8">
+      <div className="w-full max-w-lg">
+        <div className="text-center">
+          <p className="font-mono text-xs tracking-[0.3em] text-white/40">*** RESULT ***</p>
+          <h2 className="mt-2 text-2xl font-bold text-white">できた！</h2>
+        </div>
+
+        {/* コラージュ */}
+        <div className="relative mt-8 aspect-square w-full border border-white/10 bg-white/5">
+          {collageUrl ? (
+            <Image src={collageUrl} alt="コラージュ" fill className="object-cover" unoptimized />
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              <p className="font-mono text-sm text-white/30">[ コラージュ ]</p>
+            </div>
+          )}
+        </div>
+
+        {caption && (
+          <div className="mt-4 border-t border-white/10 pt-4 text-center">
+            <p className="font-mono text-xs text-white/40">CAPTION:</p>
+            <p className="mt-1 text-lg text-white">&quot;{caption}&quot;</p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/pc/shooting-screen.tsx
+++ b/src/components/pc/shooting-screen.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useSessionStore } from '@/stores/session-store'
+
+export function ShootingScreen() {
+  const { photos } = useSessionStore()
+
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-ink px-8">
+      {/* TODO: WebRTC映像をここに表示 */}
+      <div className="relative aspect-video w-full max-w-3xl border border-white/10 bg-ink-light/20">
+        <div className="flex h-full items-center justify-center">
+          <div className="text-center">
+            <p className="font-mono text-sm text-white/30">[ WebRTC映像エリア ]</p>
+            <p className="mt-1 font-mono text-xs text-white/20">バックエンド接続後に表示</p>
+          </div>
+        </div>
+
+        {/* 撮影枚数 */}
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2">
+          <div className="flex items-center gap-2">
+            {Array.from({ length: 4 }, (_, i) => (
+              <div
+                key={i}
+                className={[
+                  'h-3 w-3 rounded-full transition-all',
+                  i < photos.length ? 'bg-white' : 'bg-white/20',
+                ].join(' ')}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 text-center">
+        <p className="font-mono text-lg text-white">
+          {photos.length}/4 <span className="text-sm text-white/50">枚撮影済み</span>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/stores/room-store.ts
+++ b/src/stores/room-store.ts
@@ -1,0 +1,67 @@
+import { create } from 'zustand'
+
+type Role = 'pc' | 'phone'
+
+type RoomPhase =
+  | 'idle'
+  | 'filter-select'
+  | 'shooting'
+  | 'preview'
+  | 'processing'
+  | 'result'
+  | 'complete'
+
+type RoomState = {
+  readonly roomId: string | null
+  readonly role: Role | null
+  readonly phase: RoomPhase
+  readonly phoneConnected: boolean
+  readonly selectedFilter: string | null
+}
+
+type RoomActions = {
+  readonly createRoom: () => string
+  readonly joinRoom: (roomId: string, role: Role) => void
+  readonly setPhase: (phase: RoomPhase) => void
+  readonly setPhoneConnected: (connected: boolean) => void
+  readonly setSelectedFilter: (filter: string | null) => void
+  readonly leaveRoom: () => void
+}
+
+const initialState: RoomState = {
+  roomId: null,
+  role: null,
+  phase: 'idle',
+  phoneConnected: false,
+  selectedFilter: null,
+}
+
+function generateRoomId(): string {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+  let result = ''
+  for (let i = 0; i < 6; i++) {
+    result += chars[Math.floor(Math.random() * chars.length)]
+  }
+  return result
+}
+
+export const useRoomStore = create<RoomState & RoomActions>()((set) => ({
+  ...initialState,
+
+  createRoom: () => {
+    const roomId = generateRoomId()
+    set({ roomId, role: 'pc', phase: 'idle', phoneConnected: false })
+    return roomId
+  },
+
+  joinRoom: (roomId, role) =>
+    set({ roomId, role }),
+
+  setPhase: (phase) => set({ phase }),
+
+  setPhoneConnected: (connected) => set({ phoneConnected: connected }),
+
+  setSelectedFilter: (filter) => set({ selectedFilter: filter }),
+
+  leaveRoom: () => set(initialState),
+}))


### PR DESCRIPTION
## Summary
- ルームシステム（PC↔スマホのセッション管理基盤）
- PC画面 (`/pc`) の全フェーズ（待機→撮影→処理→結果→完了）
- エントリーページでPC/スマホの振り分け

## ルーム設計
- PC: `/pc` → ルーム作成 → QRコード表示
- スマホ: QRスキャン → `/room/[roomId]` → ルーム参加 → `/filter`
- 1ルーム = 1スマホ（バックエンド接続後に制限を厳密化）

## PC画面フェーズ
| フェーズ | 表示内容 |
|---|---|
| idle | QRコード + ルームID |
| filter-select | スマホのフィルター選択をミラー |
| shooting | WebRTC映像エリア + 撮影枚数 |
| processing | 処理進捗ステップ |
| result | コラージュ + キャプション |
| complete | 「レシートを取ってね！」→ 5秒後に待機 |

## Test plan
- [x] `npm run build` パス
- [x] `npm run lint` パス（warning 0）
- [ ] `/pc` でQRコード表示確認
- [ ] QRスキャン → `/room/xxx` → `/filter` 遷移確認