### PR TITLE
feat: お絵描き/落書き機能 (/doodle)

### DIFF
--- a/src/app/doodle/page.tsx
+++ b/src/app/doodle/page.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useCallback, useState } from 'react'
+
+import Image from 'next/image'
+
+import { DoodleEditor } from '@/components/doodle/doodle-editor'
+import type { DoodleLayer } from '@/components/doodle/types'
+import { Button } from '@/components/ui/button'
+import { PageContainer } from '@/components/ui/page-container'
+import { useSessionStore } from '@/stores/session-store'
+
+export default function DoodlePage() {
+  const router = useRouter()
+  const { photos } = useSessionStore()
+  const [editingIndex, setEditingIndex] = useState<number | null>(null)
+  const [photoLayers, setPhotoLayers] = useState<Record<number, readonly DoodleLayer[]>>({})
+
+  const handleSave = useCallback(
+    (layers: readonly DoodleLayer[]) => {
+      if (editingIndex === null) return
+      setPhotoLayers((prev) => ({ ...prev, [editingIndex]: layers }))
+      setEditingIndex(null)
+    },
+    [editingIndex],
+  )
+
+  const handleCancel = useCallback(() => {
+    setEditingIndex(null)
+  }, [])
+
+  const handleDone = useCallback(() => {
+    router.push('/processing/demo')
+  }, [router])
+
+  if (photos.length === 0) {
+    router.replace('/filter')
+    return null
+  }
+
+  // 個別編集モード
+  if (editingIndex !== null) {
+    const photo = photos[editingIndex]
+    if (!photo) return null
+
+    return (
+      <DoodleEditor
+        photoSrc={photo}
+        onSave={handleSave}
+        onCancel={handleCancel}
+        initialLayers={photoLayers[editingIndex] ?? []}
+      />
+    )
+  }
+
+  // 写真選択モード
+  return (
+    <PageContainer className="flex flex-col gap-6">
+      <header>
+        <p className="receipt-text text-[10px] tracking-[0.3em] text-ink-light">STEP 04</p>
+        <h1 className="mt-1 text-xl font-bold tracking-tight">落書きしよう</h1>
+        <p className="mt-0.5 text-xs text-ink-light">写真をタップして落書きできるよ</p>
+      </header>
+
+      <div className="grid grid-cols-2 gap-1.5">
+        {photos.map((photo, index) => {
+          const hasLayers = (photoLayers[index]?.length ?? 0) > 0
+          return (
+            <button
+              key={index}
+              type="button"
+              onClick={() => setEditingIndex(index)}
+              className="group relative aspect-[3/4] overflow-hidden border border-cream-dark"
+            >
+              <Image
+                src={photo}
+                alt={`${index + 1}枚目`}
+                fill
+                className="object-cover"
+                unoptimized
+              />
+              <div className="absolute inset-0 flex items-center justify-center bg-ink/0 transition-all group-hover:bg-ink/20 group-active:bg-ink/20">
+                <span className="bg-cream px-2 py-1 text-xs font-bold text-ink opacity-0 transition-opacity group-hover:opacity-100 group-active:opacity-100">
+                  落書きする
+                </span>
+              </div>
+              <span className="absolute top-1 left-1 bg-ink/60 px-1.5 py-0.5 font-mono text-[10px] text-white">
+                {index + 1}
+              </span>
+              {hasLayers && (
+                <span className="absolute top-1 right-1 bg-pink px-1.5 py-0.5 text-[10px] font-bold text-white">
+                  編集済
+                </span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <Button size="lg" className="w-full" onClick={handleDone}>
+          OK! 印刷する
+        </Button>
+
+        <button
+          type="button"
+          onClick={() => router.push('/preview')}
+          className="text-center text-sm text-ink-light"
+        >
+          戻る
+        </button>
+      </div>
+    </PageContainer>
+  )
+}

--- a/src/components/doodle/doodle-canvas.tsx
+++ b/src/components/doodle/doodle-canvas.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { useCallback, useEffect, useRef } from 'react'
+
+import type { DoodleLayer, StampId } from './types'
+import { STAMPS } from './types'
+
+type DoodleCanvasProps = {
+  readonly photoSrc: string
+  readonly layers: readonly DoodleLayer[]
+  readonly className?: string
+}
+
+function drawStamp(ctx: CanvasRenderingContext2D, stampId: StampId, x: number, y: number, scale: number) {
+  const stamp = STAMPS.find((s) => s.id === stampId)
+  if (!stamp) return
+
+  ctx.save()
+  ctx.translate(x, y)
+  ctx.scale(scale, scale)
+  ctx.translate(-12, -12)
+
+  const path = new Path2D(stamp.svg)
+  ctx.fillStyle = stampId === 'heart' ? '#e05280' : stampId === 'star' ? '#d4a520' : '#1a1a1a'
+  ctx.fill(path)
+  ctx.restore()
+}
+
+export function DoodleCanvas({ photoSrc, layers, className = '' }: DoodleCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const imageRef = useRef<HTMLImageElement | null>(null)
+
+  const render = useCallback(() => {
+    const canvas = canvasRef.current
+    const img = imageRef.current
+    if (!canvas || !img) return
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height)
+
+    for (const layer of layers) {
+      if (layer.type === 'path' && layer.points.length > 1) {
+        ctx.strokeStyle = layer.color
+        ctx.lineWidth = layer.size
+        ctx.lineCap = 'round'
+        ctx.lineJoin = 'round'
+        ctx.beginPath()
+        const first = layer.points[0]
+        if (first) {
+          ctx.moveTo(first.x * canvas.width, first.y * canvas.height)
+        }
+        for (let i = 1; i < layer.points.length; i++) {
+          const pt = layer.points[i]
+          if (pt) {
+            ctx.lineTo(pt.x * canvas.width, pt.y * canvas.height)
+          }
+        }
+        ctx.stroke()
+      }
+
+      if (layer.type === 'stamp') {
+        drawStamp(ctx, layer.stampId, layer.x * canvas.width, layer.y * canvas.height, layer.scale)
+      }
+
+      if (layer.type === 'text') {
+        ctx.font = `bold ${layer.fontSize}px "Zen Maru Gothic", sans-serif`
+        ctx.fillStyle = layer.color
+        ctx.textAlign = 'center'
+        ctx.fillText(layer.content, layer.x * canvas.width, layer.y * canvas.height)
+      }
+    }
+  }, [layers])
+
+  useEffect(() => {
+    const img = new Image()
+    img.crossOrigin = 'anonymous'
+    img.onload = () => {
+      imageRef.current = img
+      const canvas = canvasRef.current
+      if (canvas) {
+        canvas.width = img.naturalWidth || 640
+        canvas.height = img.naturalHeight || 480
+      }
+      render()
+    }
+    img.src = photoSrc
+  }, [photoSrc, render])
+
+  useEffect(() => {
+    render()
+  }, [render])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={`h-full w-full object-contain ${className}`}
+    />
+  )
+}

--- a/src/components/doodle/doodle-editor.tsx
+++ b/src/components/doodle/doodle-editor.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import { useCallback, useRef, useState } from 'react'
+
+import { DoodleCanvas } from './doodle-canvas'
+import { Toolbar } from './toolbar'
+import type { DoodleLayer, PenColor, PenSize, StampId, Tool } from './types'
+
+type DoodleEditorProps = {
+  readonly photoSrc: string
+  readonly onSave: (layers: readonly DoodleLayer[]) => void
+  readonly onCancel: () => void
+  readonly initialLayers?: readonly DoodleLayer[]
+}
+
+export function DoodleEditor({ photoSrc, onSave, onCancel, initialLayers = [] }: DoodleEditorProps) {
+  const [layers, setLayers] = useState<readonly DoodleLayer[]>(initialLayers)
+  const [tool, setTool] = useState<Tool>('pen')
+  const [penColor, setPenColor] = useState<PenColor>('#e05280')
+  const [penSize, setPenSize] = useState<PenSize>(4)
+  const [selectedStamp, setSelectedStamp] = useState<StampId>('heart')
+  const [textColor, setTextColor] = useState<PenColor>('#1a1a1a')
+  const [isDrawing, setIsDrawing] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const currentPathRef = useRef<{ x: number; y: number }[]>([])
+
+  const getPosition = useCallback(
+    (e: React.TouchEvent | React.MouseEvent) => {
+      const container = containerRef.current
+      if (!container) return null
+
+      const rect = container.getBoundingClientRect()
+      const clientX = 'touches' in e ? (e.touches[0]?.clientX ?? 0) : e.clientX
+      const clientY = 'touches' in e ? (e.touches[0]?.clientY ?? 0) : e.clientY
+
+      return {
+        x: (clientX - rect.left) / rect.width,
+        y: (clientY - rect.top) / rect.height,
+      }
+    },
+    [],
+  )
+
+  const handlePointerDown = useCallback(
+    (e: React.TouchEvent | React.MouseEvent) => {
+      const pos = getPosition(e)
+      if (!pos) return
+
+      if (tool === 'pen') {
+        setIsDrawing(true)
+        currentPathRef.current = [pos]
+        setLayers((prev) => [
+          ...prev,
+          { type: 'path', points: [pos], color: penColor, size: penSize },
+        ])
+      }
+
+      if (tool === 'stamp') {
+        setLayers((prev) => [
+          ...prev,
+          { type: 'stamp', stampId: selectedStamp, x: pos.x, y: pos.y, scale: 2 },
+        ])
+      }
+
+      if (tool === 'text') {
+        const content = prompt('テキストを入力')
+        if (content) {
+          setLayers((prev) => [
+            ...prev,
+            { type: 'text', content, x: pos.x, y: pos.y, color: textColor, fontSize: 24 },
+          ])
+        }
+      }
+    },
+    [tool, penColor, penSize, selectedStamp, textColor, getPosition],
+  )
+
+  const handlePointerMove = useCallback(
+    (e: React.TouchEvent | React.MouseEvent) => {
+      if (!isDrawing || tool !== 'pen') return
+      e.preventDefault()
+
+      const pos = getPosition(e)
+      if (!pos) return
+
+      currentPathRef.current = [...currentPathRef.current, pos]
+
+      setLayers((prev) => {
+        const updated = [...prev]
+        const last = updated[updated.length - 1]
+        if (last?.type === 'path') {
+          updated[updated.length - 1] = {
+            ...last,
+            points: [...last.points, pos],
+          }
+        }
+        return updated
+      })
+    },
+    [isDrawing, tool, getPosition],
+  )
+
+  const handlePointerUp = useCallback(() => {
+    setIsDrawing(false)
+    currentPathRef.current = []
+  }, [])
+
+  const handleUndo = useCallback(() => {
+    setLayers((prev) => prev.slice(0, -1))
+  }, [])
+
+  return (
+    <div className="flex min-h-dvh flex-col bg-cream">
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between px-4 py-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-sm text-ink-light"
+        >
+          キャンセル
+        </button>
+        <p className="receipt-text text-[10px] tracking-[0.3em] text-ink-light">DOODLE</p>
+        <button
+          type="button"
+          onClick={() => onSave(layers)}
+          className="text-sm font-bold text-ink"
+        >
+          完了
+        </button>
+      </div>
+
+      {/* キャンバス */}
+      <div
+        ref={containerRef}
+        className="relative mx-4 flex-1 touch-none border border-cream-dark"
+        onMouseDown={handlePointerDown}
+        onMouseMove={handlePointerMove}
+        onMouseUp={handlePointerUp}
+        onMouseLeave={handlePointerUp}
+        onTouchStart={handlePointerDown}
+        onTouchMove={handlePointerMove}
+        onTouchEnd={handlePointerUp}
+      >
+        <DoodleCanvas photoSrc={photoSrc} layers={layers} />
+      </div>
+
+      {/* ツールバー */}
+      <div className="px-4 py-3">
+        <Toolbar
+          tool={tool}
+          penColor={penColor}
+          penSize={penSize}
+          selectedStamp={selectedStamp}
+          textColor={textColor}
+          onToolChange={setTool}
+          onPenColorChange={setPenColor}
+          onPenSizeChange={setPenSize}
+          onStampChange={setSelectedStamp}
+          onTextColorChange={setTextColor}
+          onUndo={handleUndo}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/doodle/toolbar.tsx
+++ b/src/components/doodle/toolbar.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import type { PenColor, PenSize, StampId, Tool } from './types'
+import { PEN_COLORS, PEN_SIZES, STAMPS } from './types'
+
+type ToolbarProps = {
+  readonly tool: Tool
+  readonly penColor: PenColor
+  readonly penSize: PenSize
+  readonly selectedStamp: StampId
+  readonly textColor: PenColor
+  readonly onToolChange: (tool: Tool) => void
+  readonly onPenColorChange: (color: PenColor) => void
+  readonly onPenSizeChange: (size: PenSize) => void
+  readonly onStampChange: (stamp: StampId) => void
+  readonly onTextColorChange: (color: PenColor) => void
+  readonly onUndo: () => void
+}
+
+const TOOL_LABELS: Record<Tool, string> = {
+  pen: 'ペン',
+  stamp: 'スタンプ',
+  text: 'テキスト',
+}
+
+const TOOLS: readonly Tool[] = ['pen', 'stamp', 'text']
+
+export function Toolbar({
+  tool,
+  penColor,
+  penSize,
+  selectedStamp,
+  textColor,
+  onToolChange,
+  onPenColorChange,
+  onPenSizeChange,
+  onStampChange,
+  onTextColorChange,
+  onUndo,
+}: ToolbarProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      {/* ツール切り替え */}
+      <div className="flex items-center gap-1">
+        {TOOLS.map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => onToolChange(t)}
+            className={[
+              'flex-1 py-1.5 text-xs font-bold transition-all',
+              tool === t
+                ? 'bg-ink text-cream'
+                : 'bg-cream-dark/50 text-ink-light hover:bg-cream-dark',
+            ].join(' ')}
+          >
+            {TOOL_LABELS[t]}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={onUndo}
+          className="bg-cream-dark/50 px-3 py-1.5 text-xs font-bold text-ink-light hover:bg-cream-dark"
+        >
+          戻す
+        </button>
+      </div>
+
+      {/* ペン設定 */}
+      {tool === 'pen' && (
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-1.5">
+            {PEN_COLORS.map((c) => (
+              <button
+                key={c}
+                type="button"
+                onClick={() => onPenColorChange(c)}
+                className={[
+                  'h-7 w-7 rounded-full border transition-transform',
+                  penColor === c ? 'scale-110 border-ink' : 'border-cream-dark',
+                ].join(' ')}
+                style={{ backgroundColor: c }}
+              />
+            ))}
+          </div>
+          <div className="flex items-center gap-2">
+            {PEN_SIZES.map((s) => (
+              <button
+                key={s}
+                type="button"
+                onClick={() => onPenSizeChange(s)}
+                className={[
+                  'flex h-7 w-7 items-center justify-center transition-all',
+                  penSize === s ? 'bg-cream-dark' : '',
+                ].join(' ')}
+              >
+                <div
+                  className="rounded-full bg-ink"
+                  style={{ width: s + 2, height: s + 2 }}
+                />
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* スタンプ選択 */}
+      {tool === 'stamp' && (
+        <div className="flex items-center gap-1.5">
+          {STAMPS.map((s) => (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => onStampChange(s.id)}
+              className={[
+                'flex h-9 w-9 items-center justify-center transition-all',
+                selectedStamp === s.id ? 'bg-cream-dark' : 'hover:bg-cream-dark/50',
+              ].join(' ')}
+            >
+              <svg viewBox="0 0 24 24" className="h-5 w-5">
+                <path d={s.svg} fill="#1a1a1a" />
+              </svg>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* テキスト色 */}
+      {tool === 'text' && (
+        <div className="flex flex-col gap-2">
+          <p className="receipt-text text-[10px] text-ink-light">タップした位置に文字を配置</p>
+          <div className="flex items-center gap-1.5">
+            {PEN_COLORS.map((c) => (
+              <button
+                key={c}
+                type="button"
+                onClick={() => onTextColorChange(c)}
+                className={[
+                  'h-7 w-7 rounded-full border transition-transform',
+                  textColor === c ? 'scale-110 border-ink' : 'border-cream-dark',
+                ].join(' ')}
+                style={{ backgroundColor: c }}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/doodle/types.ts
+++ b/src/components/doodle/types.ts
@@ -1,0 +1,37 @@
+export type Tool = 'pen' | 'stamp' | 'text'
+
+export type PenColor = string
+export type PenSize = number
+
+export type StampId = 'heart' | 'star' | 'sparkle' | 'ribbon' | 'flower' | 'music'
+
+export type Stamp = {
+  readonly id: StampId
+  readonly label: string
+  readonly svg: string
+}
+
+export type DoodleLayer =
+  | { readonly type: 'path'; readonly points: readonly { x: number; y: number }[]; readonly color: string; readonly size: number }
+  | { readonly type: 'stamp'; readonly stampId: StampId; readonly x: number; readonly y: number; readonly scale: number }
+  | { readonly type: 'text'; readonly content: string; readonly x: number; readonly y: number; readonly color: string; readonly fontSize: number }
+
+export const PEN_COLORS: readonly string[] = [
+  '#1a1a1a',
+  '#e05280',
+  '#ffffff',
+  '#d4a520',
+  '#2aaa6a',
+  '#93c5fd',
+]
+
+export const PEN_SIZES: readonly number[] = [2, 4, 8, 14]
+
+export const STAMPS: readonly Stamp[] = [
+  { id: 'heart', label: 'ハート', svg: 'M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z' },
+  { id: 'star', label: '星', svg: 'M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z' },
+  { id: 'sparkle', label: 'キラキラ', svg: 'M12 2L14 9L22 9L16 14L18 22L12 18L6 22L8 14L2 9L10 9L12 2Z' },
+  { id: 'ribbon', label: 'リボン', svg: 'M12 2C9 2 7 4 7 6c0 1.5.8 2.8 2 3.5V11H9l-4 8h3l1-2 1 2h4l1-2 1 2h3l-4-8h-0V9.5c1.2-.7 2-2 2-3.5 0-2-2-4-5-4z' },
+  { id: 'flower', label: '花', svg: 'M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm0-18C9.8 4 8 5.8 8 8c0 2.5 2 4.5 3 7h2c1-2.5 3-4.5 3-7 0-2.2-1.8-4-4-4z' },
+  { id: 'music', label: '音符', svg: 'M12 3v10.55c-.59-.34-1.27-.55-2-.55C7.79 13 6 14.79 6 17s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z' },
+]

--- a/src/components/pc/qr-display.tsx
+++ b/src/components/pc/qr-display.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { QRCodeSVG } from 'qrcode.react'
 
 type QrDisplayProps = {
@@ -7,8 +8,13 @@ type QrDisplayProps = {
 }
 
 export function QrDisplay({ roomId }: QrDisplayProps) {
-  const origin = typeof window !== 'undefined' ? window.location.origin : ''
-  const joinUrl = `${origin}/room/${roomId}`
+  const [joinUrl, setJoinUrl] = useState('')
+
+  useEffect(() => {
+    setJoinUrl(`${window.location.origin}/room/${roomId}`)
+  }, [roomId])
+
+  if (!joinUrl) return null
 
   return (
     <div className="flex flex-col items-center gap-4">

--- a/src/components/preview/preview-view.tsx
+++ b/src/components/preview/preview-view.tsx
@@ -32,6 +32,10 @@ export function PreviewView() {
     router.push('/shoot')
   }, [clearPhotos, router])
 
+  const handleDoodle = useCallback(() => {
+    router.push('/doodle')
+  }, [router])
+
   const handleConfirm = useCallback(() => {
     router.push('/processing/demo')
   }, [router])
@@ -51,13 +55,21 @@ export function PreviewView() {
       </ReceiptFrame>
 
       <div className="flex flex-col gap-3">
-        <Button size="lg" className="w-full" onClick={handleConfirm}>
-          OK! 印刷する
+        <Button size="lg" className="w-full" onClick={handleDoodle}>
+          落書きする
         </Button>
 
-        <Button variant="secondary" size="md" className="w-full" onClick={handleRetakeAll}>
-          全部撮り直す
+        <Button variant="secondary" size="md" className="w-full" onClick={handleConfirm}>
+          そのまま印刷する
         </Button>
+
+        <button
+          type="button"
+          onClick={handleRetakeAll}
+          className="text-center text-sm text-ink-light"
+        >
+          全部撮り直す
+        </button>
       </div>
 
       <p className="receipt-text text-center font-mono text-[10px] text-ink-light">


### PR DESCRIPTION
## Summary
- プレビュー後に写真1枚ずつ落書きできるエディタ
- ペン描画（6色×4サイズ）、スタンプ（SVG 6種）、テキスト入力
- Undo機能、編集済バッジ表示

## フロー
プレビュー → 「落書きする」→ 写真選択 → 個別編集 → 完了 → 印刷

## Test plan
- [x] `npm run build` パス
- [x] `npm run lint` パス
- [ ] /doodle で写真選択→ペン描画確認
- [ ] スタンプ配置、テキスト入力確認
- [ ] Undo動作確認