### PR TITLE
feat: バックエンドAPI接続

### DIFF
--- a/src/components/processing/processing-view.tsx
+++ b/src/components/processing/processing-view.tsx
@@ -1,12 +1,16 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useEffect } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { PageContainer } from '@/components/ui/page-container'
-import { ReceiptFrame } from '@/components/ui/receipt-frame'
+import { createSession, startProcessing, uploadPhoto } from '@/lib/api/sessions'
+import type { WsEvent } from '@/lib/api/types'
+import { toApiFilterName } from '@/lib/filters'
+import { dataUrlToBlob } from '@/lib/utils'
 import { useSessionStore } from '@/stores/session-store'
 
+import { PageContainer } from '../ui/page-container'
+import { ReceiptFrame } from '../ui/receipt-frame'
 import { ProcessingSteps } from './processing-steps'
 import { ReceiptPrinterAnimation } from './receipt-printer-animation'
 
@@ -14,37 +18,133 @@ type ProcessingViewProps = {
   readonly sessionId: string
 }
 
-const STEP_ORDER = [
-  'uploading',
-  'face-detection',
-  'filter-apply',
-  'collage-generate',
-  'print-prepare',
-  'complete',
-] as const
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? ''
 
-export function ProcessingView({ sessionId }: ProcessingViewProps) {
+const STEP_MAP: Record<string, string> = {
+  'face-detection': 'face-detection',
+  'filter': 'filter-apply',
+  'collage': 'collage-generate',
+  'caption': 'collage-generate',
+  'dither': 'print-prepare',
+}
+
+export function ProcessingView({ sessionId: routeSessionId }: ProcessingViewProps) {
   const router = useRouter()
-  const { processingStep, setProcessingStep } = useSessionStore()
+  const { photos, filter, processingStep, setProcessingStep, setResult } = useSessionStore()
+  const [error, setError] = useState<string | null>(null)
+  const [currentSessionId, setCurrentSessionId] = useState<string | null>(null)
+  const wsRef = useRef<WebSocket | null>(null)
+  const startedRef = useRef(false)
 
-  // TODO: WebSocket接続でバックエンドから進捗を受け取る
-  // 現在はデモ用に自動進行
-  useEffect(() => {
-    let stepIndex = 0
-    const interval = setInterval(() => {
-      stepIndex += 1
-      if (stepIndex >= STEP_ORDER.length) {
-        clearInterval(interval)
-        router.push(`/result/${sessionId}`)
-        return
+  const handleWsEvent = useCallback(
+    (event: WsEvent) => {
+      if (event.type === 'statusUpdate') {
+        const mapped = STEP_MAP[event.data.step] ?? event.data.step
+        setProcessingStep(mapped as Parameters<typeof setProcessingStep>[0])
       }
-      setProcessingStep(STEP_ORDER[stepIndex] ?? 'uploading')
-    }, 2000)
 
-    setProcessingStep('uploading')
+      if (event.type === 'completed') {
+        setResult(event.data.collageImageUrl, null)
+        router.push(`/result/${event.data.sessionId}`)
+      }
 
-    return () => clearInterval(interval)
-  }, [sessionId, setProcessingStep, router])
+      if (event.type === 'error') {
+        setError(event.data.message)
+      }
+    },
+    [setProcessingStep, setResult, router],
+  )
+
+  useEffect(() => {
+    if (startedRef.current) return
+    startedRef.current = true
+
+    const run = async () => {
+      try {
+        if (!filter || photos.length === 0) {
+          // デモモード: バックエンド未接続時のフォールバック
+          setProcessingStep('uploading')
+          const steps = ['uploading', 'face-detection', 'filter-apply', 'collage-generate', 'print-prepare', 'complete'] as const
+          for (let i = 0; i < steps.length; i++) {
+            await new Promise((r) => setTimeout(r, 1500))
+            setProcessingStep(steps[i] ?? 'uploading')
+          }
+          router.push(`/result/${routeSessionId}`)
+          return
+        }
+
+        // 1. セッション作成
+        setProcessingStep('uploading')
+        const session = await createSession({
+          filterType: filter.type,
+          filter: toApiFilterName(filter.value),
+          photoCount: photos.length,
+        })
+        setCurrentSessionId(session.sessionId)
+
+        // 2. WebSocket接続 + subscribe
+        if (WS_URL) {
+          const ws = new WebSocket(WS_URL)
+          wsRef.current = ws
+
+          ws.addEventListener('open', () => {
+            ws.send(JSON.stringify({
+              action: 'subscribe',
+              data: { sessionId: session.sessionId },
+            }))
+          })
+
+          ws.addEventListener('message', (e) => {
+            try {
+              const parsed = JSON.parse(e.data as string) as WsEvent
+              handleWsEvent(parsed)
+            } catch {
+              // ignore
+            }
+          })
+        }
+
+        // 3. 写真アップロード（並列）
+        await Promise.all(
+          session.uploadUrls.map((upload, i) => {
+            const photo = photos[i]
+            if (!photo) return Promise.resolve()
+            const blob = dataUrlToBlob(photo)
+            return uploadPhoto(upload.url, blob)
+          }),
+        )
+
+        // 4. 処理開始
+        setProcessingStep('face-detection')
+        await startProcessing(session.sessionId)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : '処理中にエラーが発生しました'
+        setError(message)
+      }
+    }
+
+    void run()
+
+    return () => {
+      wsRef.current?.close()
+      wsRef.current = null
+    }
+  }, [routeSessionId, photos, filter, setProcessingStep, setResult, router, handleWsEvent])
+
+  if (error) {
+    return (
+      <PageContainer className="flex flex-col items-center justify-center gap-4">
+        <p className="receipt-text text-sm font-bold text-red">{error}</p>
+        <button
+          type="button"
+          onClick={() => router.replace('/filter')}
+          className="text-sm text-ink-light underline"
+        >
+          最初からやり直す
+        </button>
+      </PageContainer>
+    )
+  }
 
   return (
     <PageContainer className="flex flex-col items-center justify-center gap-8">
@@ -62,7 +162,9 @@ export function ProcessingView({ sessionId }: ProcessingViewProps) {
         <ProcessingSteps currentStep={processingStep ?? 'uploading'} />
 
         <div className="mt-3 border-t border-dashed border-ink-light/30 pt-2 text-center">
-          <p className="font-mono text-[10px] text-ink-light">No. {sessionId}</p>
+          <p className="font-mono text-[10px] text-ink-light">
+            No. {currentSessionId ?? routeSessionId}
+          </p>
         </div>
       </ReceiptFrame>
     </PageContainer>

--- a/src/components/result/result-view.tsx
+++ b/src/components/result/result-view.tsx
@@ -2,19 +2,46 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
+import { useEffect, useState } from 'react'
 
-import { Button } from '@/components/ui/button'
-import { PageContainer } from '@/components/ui/page-container'
-import { ReceiptFrame } from '@/components/ui/receipt-frame'
+import { getSession } from '@/lib/api/sessions'
+import { useSessionStore } from '@/stores/session-store'
+
+import { Button } from '../ui/button'
+import { PageContainer } from '../ui/page-container'
+import { ReceiptFrame } from '../ui/receipt-frame'
 
 type ResultViewProps = {
   readonly sessionId: string
 }
 
 export function ResultView({ sessionId }: ResultViewProps) {
-  // TODO: sessionId でバックエンドから結果を取得
-  const collageUrl: string | null = null
-  const caption = 'みんなの笑顔が最高にキュートだね！'
+  const { collageUrl: storeCollageUrl, caption: storeCaption } = useSessionStore()
+  const [collageUrl, setCollageUrl] = useState<string | null>(storeCollageUrl)
+  const [caption, setCaption] = useState<string | null>(storeCaption)
+  const [loading, setLoading] = useState(!storeCollageUrl)
+
+  useEffect(() => {
+    if (storeCollageUrl) return
+
+    const fetchSession = async () => {
+      try {
+        const session = await getSession(sessionId)
+        if (session.collageImageUrl) {
+          setCollageUrl(session.collageImageUrl)
+        }
+        if (session.caption) {
+          setCaption(session.caption)
+        }
+      } catch {
+        // ignore - show placeholder
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    void fetchSession()
+  }, [sessionId, storeCollageUrl])
 
   return (
     <PageContainer className="flex flex-col items-center gap-6">
@@ -32,7 +59,6 @@ export function ResultView({ sessionId }: ResultViewProps) {
           <div className="my-2 border-t border-dashed border-ink-light/30" />
         </div>
 
-        {/* コラージュ画像 */}
         <div className="relative aspect-square border border-dashed border-ink-light/30 bg-cream-dark/20">
           {collageUrl ? (
             <Image
@@ -45,18 +71,25 @@ export function ResultView({ sessionId }: ResultViewProps) {
           ) : (
             <div className="flex h-full items-center justify-center">
               <div className="receipt-text text-center text-ink-light">
-                <p className="text-xs">[ コラージュ画像 ]</p>
-                <p className="mt-1 text-[10px]">バックエンド接続後に表示</p>
+                {loading ? (
+                  <p className="animate-pulse text-xs">読み込み中...</p>
+                ) : (
+                  <>
+                    <p className="text-xs">[ コラージュ画像 ]</p>
+                    <p className="mt-1 text-[10px]">バックエンド接続後に表示</p>
+                  </>
+                )}
               </div>
             </div>
           )}
         </div>
 
-        {/* AIキャプション */}
-        <div className="mt-3 border-t border-dashed border-ink-light/30 pt-3">
-          <p className="receipt-text text-xs text-ink-light">CAPTION:</p>
-          <p className="mt-1 text-sm leading-relaxed">&quot;{caption}&quot;</p>
-        </div>
+        {caption && (
+          <div className="mt-3 border-t border-dashed border-ink-light/30 pt-3">
+            <p className="receipt-text text-xs text-ink-light">CAPTION:</p>
+            <p className="mt-1 text-sm leading-relaxed">&quot;{caption}&quot;</p>
+          </div>
+        )}
 
         <div className="mt-3 border-t border-dashed border-ink-light/30 pt-2 text-center">
           <p className="font-mono text-[10px] text-ink-light">
@@ -66,9 +99,13 @@ export function ResultView({ sessionId }: ResultViewProps) {
       </ReceiptFrame>
 
       <div className="flex w-full flex-col gap-3">
-        <Button size="lg" className="w-full" disabled={!collageUrl}>
-          画像を保存
-        </Button>
+        {collageUrl && (
+          <a href={collageUrl} download className="w-full">
+            <Button size="lg" className="w-full">
+              画像を保存
+            </Button>
+          </a>
+        )}
 
         <Link href="/filter" className="w-full">
           <Button variant="secondary" size="md" className="w-full">

--- a/src/hooks/use-websocket.ts
+++ b/src/hooks/use-websocket.ts
@@ -1,0 +1,78 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { WsEvent } from '@/lib/api/types'
+
+type UseWebSocketReturn = {
+  readonly isConnected: boolean
+  readonly subscribe: (sessionId: string) => void
+  readonly sendMessage: (action: string, data: Record<string, unknown>) => void
+}
+
+type UseWebSocketOptions = {
+  readonly url: string
+  readonly onEvent: (event: WsEvent) => void
+}
+
+export function useWebSocket({ url, onEvent }: UseWebSocketOptions): UseWebSocketReturn {
+  const wsRef = useRef<WebSocket | null>(null)
+  const [isConnected, setIsConnected] = useState(false)
+  const onEventRef = useRef(onEvent)
+
+  useEffect(() => {
+    onEventRef.current = onEvent
+  }, [onEvent])
+
+  useEffect(() => {
+    if (!url) return
+
+    const ws = new WebSocket(url)
+    wsRef.current = ws
+
+    ws.addEventListener('open', () => {
+      setIsConnected(true)
+    })
+
+    ws.addEventListener('message', (event) => {
+      try {
+        const parsed = JSON.parse(event.data as string) as WsEvent
+        onEventRef.current(parsed)
+      } catch {
+        // ignore non-JSON messages
+      }
+    })
+
+    ws.addEventListener('close', () => {
+      setIsConnected(false)
+    })
+
+    ws.addEventListener('error', () => {
+      setIsConnected(false)
+    })
+
+    return () => {
+      ws.close()
+      wsRef.current = null
+    }
+  }, [url])
+
+  const subscribe = useCallback((sessionId: string) => {
+    const ws = wsRef.current
+    if (!ws || ws.readyState !== WebSocket.OPEN) return
+
+    ws.send(JSON.stringify({
+      action: 'subscribe',
+      data: { sessionId },
+    }))
+  }, [])
+
+  const sendMessage = useCallback((action: string, data: Record<string, unknown>) => {
+    const ws = wsRef.current
+    if (!ws || ws.readyState !== WebSocket.OPEN) return
+
+    ws.send(JSON.stringify({ action, data }))
+  }, [])
+
+  return { isConnected, subscribe, sendMessage }
+}

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -2,14 +2,14 @@ import type { ApiResponse } from './types'
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL
 
-if (!API_BASE_URL) {
-  throw new Error('NEXT_PUBLIC_API_BASE_URL is not configured')
-}
-
 export async function apiRequest<T>(
   path: string,
   options: RequestInit = {},
 ): Promise<ApiResponse<T>> {
+  if (!API_BASE_URL) {
+    return { success: false, error: 'API_BASE_URL is not configured' }
+  }
+
   const url = `${API_BASE_URL}${path}`
 
   try {
@@ -22,9 +22,10 @@ export async function apiRequest<T>(
     })
 
     if (!response.ok) {
+      const body = await response.json().catch(() => ({})) as { error?: string }
       return {
         success: false,
-        error: `HTTP ${response.status}: ${response.statusText}`,
+        error: body.error ?? `HTTP ${response.status}: ${response.statusText}`,
       }
     }
 

--- a/src/lib/api/sessions.ts
+++ b/src/lib/api/sessions.ts
@@ -1,27 +1,57 @@
 import { apiRequest } from './client'
-import type { CreateSessionRequest, CreateSessionResponse, SessionStatus } from './types'
+import type {
+  CreateSessionRequest,
+  CreateSessionResponse,
+  ProcessStartResponse,
+  SessionResponse,
+} from './types'
 
 export async function createSession(
   request: CreateSessionRequest,
 ): Promise<CreateSessionResponse> {
-  const result = await apiRequest<CreateSessionResponse>('/sessions', {
+  const result = await apiRequest<CreateSessionResponse>('/api/session', {
     method: 'POST',
     body: JSON.stringify(request),
   })
 
   if (!result.success || !result.data) {
-    throw new Error(result.error ?? 'Failed to create session')
+    throw new Error(result.error ?? 'セッションの作成に失敗しました')
   }
 
   return result.data
 }
 
-export async function getSessionStatus(sessionId: string): Promise<SessionStatus> {
-  const result = await apiRequest<SessionStatus>(`/sessions/${sessionId}`)
+export async function getSession(sessionId: string): Promise<SessionResponse> {
+  const result = await apiRequest<SessionResponse>(`/api/session/${sessionId}`)
 
   if (!result.success || !result.data) {
-    throw new Error(result.error ?? 'Failed to get session status')
+    throw new Error(result.error ?? 'セッション情報の取得に失敗しました')
   }
 
   return result.data
+}
+
+export async function startProcessing(sessionId: string): Promise<ProcessStartResponse> {
+  const result = await apiRequest<ProcessStartResponse>(
+    `/api/session/${sessionId}/process`,
+    { method: 'POST' },
+  )
+
+  if (!result.success || !result.data) {
+    throw new Error(result.error ?? '処理の開始に失敗しました')
+  }
+
+  return result.data
+}
+
+export async function uploadPhoto(uploadUrl: string, photoBlob: Blob): Promise<void> {
+  const response = await fetch(uploadUrl, {
+    method: 'PUT',
+    body: photoBlob,
+    headers: { 'Content-Type': 'image/jpeg' },
+  })
+
+  if (!response.ok) {
+    throw new Error(`写真のアップロードに失敗しました: HTTP ${response.status}`)
+  }
 }

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -4,21 +4,73 @@ export type ApiResponse<T> = {
   readonly error?: string
 }
 
+export type SimpleFilter = 'natural' | 'beauty' | 'bright' | 'mono' | 'sepia'
+export type AiFilter = 'anime' | 'popart' | 'watercolor'
+
 export type CreateSessionRequest = {
   readonly filterType: 'simple' | 'ai'
-  readonly filter: string
+  readonly filter: SimpleFilter | AiFilter
   readonly photoCount: number
+}
+
+export type UploadUrl = {
+  readonly index: number
+  readonly url: string
 }
 
 export type CreateSessionResponse = {
   readonly sessionId: string
-  readonly uploadUrls: readonly string[]
+  readonly uploadUrls: readonly UploadUrl[]
+  readonly websocketUrl: string
 }
 
-export type SessionStatus = {
+export type SessionStatus =
+  | 'uploading'
+  | 'processing'
+  | 'completed'
+  | 'printed'
+  | 'failed'
+
+export type SessionResponse = {
   readonly sessionId: string
-  readonly status: 'uploading' | 'processing' | 'complete' | 'error'
-  readonly step?: string
-  readonly collageUrl?: string
+  readonly status: SessionStatus
+  readonly filterType: 'simple' | 'ai'
+  readonly filter: string
   readonly caption?: string
+  readonly collageImageUrl?: string
+  readonly createdAt: string
 }
+
+export type ProcessStartResponse = {
+  readonly sessionId: string
+  readonly status: 'processing'
+}
+
+export type WsProgressEvent = {
+  readonly type: 'statusUpdate'
+  readonly data: {
+    readonly sessionId: string
+    readonly status: string
+    readonly step: string
+    readonly progress: number
+    readonly message: string
+  }
+}
+
+export type WsCompletedEvent = {
+  readonly type: 'completed'
+  readonly data: {
+    readonly sessionId: string
+    readonly collageImageUrl: string
+  }
+}
+
+export type WsErrorEvent = {
+  readonly type: 'error'
+  readonly data: {
+    readonly sessionId: string
+    readonly message: string
+  }
+}
+
+export type WsEvent = WsProgressEvent | WsCompletedEvent | WsErrorEvent

--- a/src/lib/filters.ts
+++ b/src/lib/filters.ts
@@ -82,3 +82,22 @@ export const AI_FILTERS: readonly FilterInfo[] = [
 ] as const
 
 export const ALL_FILTERS: readonly FilterInfo[] = [...SIMPLE_FILTERS, ...AI_FILTERS]
+
+import type { AiFilter, SimpleFilter } from './api/types'
+
+type ApiFilter = SimpleFilter | AiFilter
+
+const FILTER_ID_TO_API: Record<FilterId, ApiFilter> = {
+  'natural': 'natural',
+  'skin-smooth': 'beauty',
+  'brightness': 'bright',
+  'monochrome': 'mono',
+  'sepia': 'sepia',
+  'anime': 'anime',
+  'pop-art': 'popart',
+  'watercolor': 'watercolor',
+}
+
+export function toApiFilterName(filterId: FilterId): ApiFilter {
+  return FILTER_ID_TO_API[filterId]
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,13 @@
+export function dataUrlToBlob(dataUrl: string): Blob {
+  const parts = dataUrl.split(',')
+  const mimeMatch = parts[0]?.match(/:(.*?);/)
+  const mime = mimeMatch?.[1] ?? 'image/jpeg'
+  const bstr = atob(parts[1] ?? '')
+  const u8arr = new Uint8Array(bstr.length)
+
+  for (let i = 0; i < bstr.length; i++) {
+    u8arr[i] = bstr.charCodeAt(i)
+  }
+
+  return new Blob([u8arr], { type: mime })
+}


### PR DESCRIPTION
## Summary
- REST API: セッション作成 + S3 Presigned URLアップロード + 処理開始
- WebSocket: 処理進捗リアルタイム受信 + 完了通知
- 結果画面: バックエンドからコラージュ画像・キャプション取得
- フィルターIDマッピング（フロント↔バックエンド命名差異の吸収）

## 接続フロー
1. POST /api/session → sessionId + uploadUrls + websocketUrl
2. PUT uploadUrls[i] → S3に写真アップロード（並列）
3. WebSocket subscribe → sessionIdの進捗監視
4. POST /api/session/{id}/process → 処理開始
5. WebSocket statusUpdate → 進捗表示更新
6. WebSocket completed → /result/{id} に遷移
7. GET /api/session/{id} → コラージュURL・キャプション取得

## 環境変数
- `NEXT_PUBLIC_API_BASE_URL`: REST APIエンドポイント
- `NEXT_PUBLIC_WS_URL`: WebSocketエンドポイント
- Amplify側にも設定が必要

## Test plan
- [x] `npm run build` パス
- [x] `npm run lint` パス
- [ ] 実際のバックエンドと接続テスト