### PR TITLE
feat: WebRTC + 撮影同期 + やじコメント

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -70,3 +70,8 @@ body {
   0% { opacity: 0.9; }
   100% { opacity: 0; }
 }
+
+@keyframes yajiSlide {
+  0% { right: -100%; }
+  100% { right: 110%; }
+}

--- a/src/components/pc/pc-view.tsx
+++ b/src/components/pc/pc-view.tsx
@@ -1,7 +1,9 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
+import { useShootingSync } from '@/hooks/use-shooting-sync'
+import { useWebRtc } from '@/hooks/use-webrtc'
 import { useRoomStore } from '@/stores/room-store'
 
 import { CompleteScreen } from './complete-screen'
@@ -11,14 +13,106 @@ import { ProcessingScreen } from './processing-screen'
 import { ResultScreen } from './result-screen'
 import { ShootingScreen } from './shooting-screen'
 
-export function PcView() {
-  const { roomId, phase, createRoom } = useRoomStore()
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? ''
 
+export function PcView() {
+  const { roomId, phase, createRoom, setPhase, setPhoneConnected } = useRoomStore()
+  const wsRef = useRef<WebSocket | null>(null)
+  const [countdownValue, setCountdownValue] = useState<number | null>(null)
+  const [lastShutterIndex, setLastShutterIndex] = useState<number | null>(null)
+
+  // ルーム作成
   useEffect(() => {
     if (!roomId) {
       createRoom()
     }
   }, [roomId, createRoom])
+
+  // WebSocket接続
+  useEffect(() => {
+    if (!roomId || !WS_URL) return
+
+    const ws = new WebSocket(WS_URL)
+    wsRef.current = ws
+
+    ws.addEventListener('open', () => {
+      // ルーム参加
+      ws.send(JSON.stringify({
+        action: 'join_room',
+        data: { roomId, role: 'pc' },
+      }))
+    })
+
+    ws.addEventListener('message', (event) => {
+      try {
+        const msg = JSON.parse(event.data as string) as {
+          type: string
+          data: Record<string, unknown>
+        }
+
+        // スマホが参加したらフェーズ遷移
+        if (msg.type === 'shooting_sync') {
+          const syncEvent = msg.data.event as string
+          if (syncEvent === 'shooting_start') {
+            setPhase('shooting')
+            setPhoneConnected(true)
+          }
+          if (syncEvent === 'shooting_complete') {
+            setPhase('preview')
+          }
+        }
+      } catch {
+        // ignore
+      }
+    })
+
+    return () => {
+      ws.close()
+      wsRef.current = null
+    }
+  }, [roomId, setPhase, setPhoneConnected])
+
+  // WebRTC（PC側：受信のみ）
+  const { remoteStream } = useWebRtc({
+    wsRef,
+    roomId,
+    role: 'pc',
+  })
+
+  // WebRTC接続確立でフェーズ遷移
+  useEffect(() => {
+    if (remoteStream && phase === 'idle') {
+      setPhase('filter-select')
+      setPhoneConnected(true)
+    }
+  }, [remoteStream, phase, setPhase, setPhoneConnected])
+
+  // 撮影イベント受信
+  const handleShootingEvent = useCallback(
+    (data: { event: string; count?: number; photoIndex?: number }) => {
+      if (data.event === 'countdown' && data.count !== undefined) {
+        setCountdownValue(data.count)
+      }
+      if (data.event === 'shutter') {
+        setCountdownValue(null)
+        setLastShutterIndex(data.photoIndex ?? null)
+      }
+      if (data.event === 'shooting_start') {
+        setPhase('shooting')
+      }
+      if (data.event === 'shooting_complete') {
+        setCountdownValue(null)
+        setPhase('preview')
+      }
+    },
+    [setPhase],
+  )
+
+  useShootingSync({
+    wsRef,
+    roomId,
+    onEvent: handleShootingEvent,
+  })
 
   if (!roomId) return null
 
@@ -29,7 +123,14 @@ export function PcView() {
       return <FilterScreen />
     case 'shooting':
     case 'preview':
-      return <ShootingScreen />
+      return (
+        <ShootingScreen
+          remoteStream={remoteStream}
+          wsRef={wsRef}
+          countdownValue={countdownValue}
+          lastShutterIndex={lastShutterIndex}
+        />
+      )
     case 'processing':
       return <ProcessingScreen />
     case 'result':

--- a/src/components/pc/shooting-screen.tsx
+++ b/src/components/pc/shooting-screen.tsx
@@ -1,42 +1,86 @@
 'use client'
 
+import { useEffect, useRef } from 'react'
+
 import { useSessionStore } from '@/stores/session-store'
 
-export function ShootingScreen() {
+import { YajiComment } from './yaji-comment'
+
+type ShootingScreenProps = {
+  readonly remoteStream: MediaStream | null
+  readonly wsRef: React.RefObject<WebSocket | null>
+  readonly countdownValue: number | null
+  readonly lastShutterIndex: number | null
+}
+
+export function ShootingScreen({
+  remoteStream,
+  wsRef,
+  countdownValue,
+  lastShutterIndex,
+}: ShootingScreenProps) {
   const { photos } = useSessionStore()
+  const videoRef = useRef<HTMLVideoElement>(null)
+
+  useEffect(() => {
+    const video = videoRef.current
+    if (!video || !remoteStream) return
+    video.srcObject = remoteStream
+  }, [remoteStream])
 
   return (
-    <div className="flex min-h-dvh flex-col items-center justify-center px-8">
-      <div className="w-full max-w-3xl">
-        <header className="mb-6 text-center">
-          <p className="receipt-text text-[10px] tracking-[0.3em] text-ink-light">STEP 02</p>
-          <h2 className="mt-1 text-2xl font-bold tracking-tight">撮影中</h2>
-        </header>
+    <div className="relative flex min-h-dvh flex-col items-center justify-center px-8">
+      <header className="mb-4 text-center">
+        <p className="receipt-text text-[10px] tracking-[0.3em] text-ink-light">STEP 02</p>
+        <h2 className="mt-1 text-2xl font-bold tracking-tight">撮影中</h2>
+      </header>
 
-        {/* TODO: WebRTC映像をここに表示 */}
-        <div className="aspect-video w-full border border-cream-dark bg-cream-dark/20">
-          <div className="flex h-full items-center justify-center">
-            <div className="receipt-text text-center text-ink-light">
-              <p className="text-sm">[ WebRTC映像エリア ]</p>
-              <p className="mt-1 text-[10px]">バックエンド接続後に表示</p>
-            </div>
+      <div className="relative aspect-video w-full max-w-3xl border border-cream-dark overflow-hidden">
+        {remoteStream ? (
+          <video
+            ref={videoRef}
+            autoPlay
+            playsInline
+            muted
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center bg-cream-dark/20">
+            <p className="receipt-text text-sm text-ink-light">カメラ映像を待機中...</p>
           </div>
-        </div>
+        )}
 
-        <div className="mt-4 flex items-center justify-center gap-3">
-          {Array.from({ length: 4 }, (_, i) => (
-            <div
-              key={i}
-              className={[
-                'h-3 w-3 rounded-full transition-all',
-                i < photos.length ? 'bg-ink' : 'bg-cream-dark',
-              ].join(' ')}
-            />
-          ))}
-          <p className="receipt-text ml-2 text-sm text-ink-light">
-            {photos.length}/4 枚撮影済み
-          </p>
-        </div>
+        {/* カウントダウン */}
+        {countdownValue !== null && countdownValue > 0 && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <span className="font-mono text-[120px] font-bold text-white drop-shadow-[0_2px_4px_rgba(0,0,0,0.5)]">
+              {countdownValue}
+            </span>
+          </div>
+        )}
+
+        {/* シャッターフラッシュ */}
+        {lastShutterIndex !== null && (
+          <div key={lastShutterIndex} className="absolute inset-0 animate-[flash_200ms_ease-out_forwards] bg-white" />
+        )}
+
+        {/* やじコメント */}
+        <YajiComment wsRef={wsRef} />
+      </div>
+
+      <div className="mt-4 flex items-center justify-center gap-3">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div
+            key={i}
+            className={[
+              'h-3 w-3 rounded-full transition-all',
+              i < photos.length ? 'bg-ink' : 'bg-cream-dark',
+            ].join(' ')}
+          />
+        ))}
+        <p className="receipt-text ml-2 text-sm text-ink-light">
+          {photos.length}/4 枚撮影済み
+        </p>
       </div>
     </div>
   )

--- a/src/components/pc/yaji-comment.tsx
+++ b/src/components/pc/yaji-comment.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+type Comment = {
+  readonly id: number
+  readonly text: string
+  readonly lane: number
+  readonly startTime: number
+}
+
+type YajiCommentProps = {
+  readonly wsRef: React.RefObject<WebSocket | null>
+}
+
+const LANE_COUNT = 8
+const COMMENT_DURATION = 5000
+
+let commentId = 0
+
+export function YajiComment({ wsRef }: YajiCommentProps) {
+  const [comments, setComments] = useState<readonly Comment[]>([])
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const ws = wsRef.current
+    if (!ws) return
+
+    const handler = (event: MessageEvent) => {
+      try {
+        const msg = JSON.parse(event.data as string) as {
+          type: string
+          data: { text: string }
+        }
+
+        if (msg.type === 'yajiComment') {
+          commentId += 1
+          const newComment: Comment = {
+            id: commentId,
+            text: msg.data.text,
+            lane: Math.floor(Math.random() * LANE_COUNT),
+            startTime: Date.now(),
+          }
+
+          setComments((prev) => [...prev, newComment])
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    ws.addEventListener('message', handler)
+    return () => ws.removeEventListener('message', handler)
+  }, [wsRef])
+
+  // 古いコメントを定期的に削除
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const now = Date.now()
+      setComments((prev) =>
+        prev.filter((c) => now - c.startTime < COMMENT_DURATION),
+      )
+    }, 1000)
+
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <div
+      ref={containerRef}
+      className="pointer-events-none absolute inset-0 overflow-hidden"
+    >
+      {comments.map((comment) => (
+        <div
+          key={comment.id}
+          className="absolute whitespace-nowrap font-bold text-white animate-[yajiSlide_5s_linear_forwards]"
+          style={{
+            top: `${(comment.lane / LANE_COUNT) * 80 + 5}%`,
+            textShadow: '1px 1px 2px rgba(0,0,0,0.5)',
+            fontSize: '20px',
+          }}
+        >
+          {comment.text}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/shoot/shoot-view.tsx
+++ b/src/components/shoot/shoot-view.tsx
@@ -1,39 +1,140 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { StepIndicator } from '@/components/ui/step-indicator'
 import { useCamera } from '@/hooks/use-camera'
 import { useCountdown } from '@/hooks/use-countdown'
+import { useRoomStore } from '@/stores/room-store'
 import { useSessionStore } from '@/stores/session-store'
 
 import { CountdownOverlay } from './countdown-overlay'
 import { FlashOverlay } from './flash-overlay'
 
 const TOTAL_PHOTOS = 4
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? ''
 
 export function ShootView() {
   const router = useRouter()
-  const { videoRef, isReady, error, capture } = useCamera()
+  const { videoRef, isReady, error, capture, stream } = useCamera()
   const { count, isRunning, start: startCountdown } = useCountdown()
   const { filter, addPhoto, photos } = useSessionStore()
+  const { roomId } = useRoomStore()
   const [flashTrigger, setFlashTrigger] = useState(0)
   const isShootingRef = useRef(false)
+  const wsRef = useRef<WebSocket | null>(null)
 
   const photoCount = photos.length
+
+  // WebSocket接続 + WebRTC映像送信
+  useEffect(() => {
+    if (!WS_URL || !roomId) return
+
+    const ws = new WebSocket(WS_URL)
+    wsRef.current = ws
+
+    ws.addEventListener('open', () => {
+      ws.send(JSON.stringify({
+        action: 'join_room',
+        data: { roomId, role: 'phone' },
+      }))
+    })
+
+    return () => {
+      ws.close()
+      wsRef.current = null
+    }
+  }, [roomId])
+
+  // WebRTCでカメラ映像をPCに送信
+  useEffect(() => {
+    if (!stream || !roomId || !wsRef.current) return
+
+    const ws = wsRef.current
+    if (ws.readyState !== WebSocket.OPEN) return
+
+    const pc = new RTCPeerConnection({
+      iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+    })
+
+    stream.getTracks().forEach((track) => pc.addTrack(track, stream))
+
+    pc.onicecandidate = (event) => {
+      if (event.candidate) {
+        ws.send(JSON.stringify({
+          action: 'webrtc_ice',
+          data: { roomId, candidate: JSON.stringify(event.candidate) },
+        }))
+      }
+    }
+
+    const handleMessage = (event: MessageEvent) => {
+      try {
+        const msg = JSON.parse(event.data as string) as {
+          type: string
+          data: { sdp?: string; candidate?: string }
+        }
+        if (msg.type === 'webrtc_answer' && msg.data.sdp) {
+          void pc.setRemoteDescription(new RTCSessionDescription({ type: 'answer', sdp: msg.data.sdp }))
+        }
+        if (msg.type === 'webrtc_ice' && msg.data.candidate) {
+          const candidate = JSON.parse(msg.data.candidate) as RTCIceCandidateInit
+          void pc.addIceCandidate(new RTCIceCandidate(candidate))
+        }
+      } catch { /* ignore */ }
+    }
+
+    ws.addEventListener('message', handleMessage)
+
+    const startOffer = async () => {
+      const offer = await pc.createOffer()
+      await pc.setLocalDescription(offer)
+      ws.send(JSON.stringify({
+        action: 'webrtc_offer',
+        data: { roomId, sdp: offer.sdp },
+      }))
+    }
+
+    void startOffer()
+
+    return () => {
+      ws.removeEventListener('message', handleMessage)
+      pc.close()
+    }
+  }, [stream, roomId])
+
+  const sendSync = useCallback(
+    (event: string, extra?: Record<string, unknown>) => {
+      const ws = wsRef.current
+      if (!ws || ws.readyState !== WebSocket.OPEN || !roomId) return
+      ws.send(JSON.stringify({
+        action: 'shooting_sync',
+        data: { roomId, event, ...extra },
+      }))
+    },
+    [roomId],
+  )
 
   const shootSequence = useCallback(async () => {
     if (isShootingRef.current) return
     isShootingRef.current = true
 
+    sendSync('shooting_start', { totalPhotos: TOTAL_PHOTOS })
+
     for (let i = photoCount; i < TOTAL_PHOTOS; i++) {
+      // カウントダウン送信
+      for (let c = 3; c > 0; c--) {
+        sendSync('countdown', { photoIndex: i, count: c })
+      }
+
       await startCountdown(3)
 
       const dataUrl = capture()
       if (dataUrl) {
         addPhoto(dataUrl)
         setFlashTrigger((prev) => prev + 1)
+        sendSync('shutter', { photoIndex: i })
       }
 
       if (i < TOTAL_PHOTOS - 1) {
@@ -41,9 +142,10 @@ export function ShootView() {
       }
     }
 
+    sendSync('shooting_complete')
     isShootingRef.current = false
     router.push('/preview')
-  }, [photoCount, startCountdown, capture, addPhoto, router])
+  }, [photoCount, startCountdown, capture, addPhoto, router, sendSync])
 
   if (!filter) {
     router.replace('/filter')

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 type UseCameraReturn = {
   readonly videoRef: React.RefObject<HTMLVideoElement | null>
+  readonly stream: MediaStream | null
   readonly isReady: boolean
   readonly error: string | null
   readonly capture: () => string | null
@@ -13,6 +14,7 @@ export function useCamera(): UseCameraReturn {
   const videoRef = useRef<HTMLVideoElement | null>(null)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const streamRef = useRef<MediaStream | null>(null)
+  const [stream, setStream] = useState<MediaStream | null>(null)
   const [isReady, setIsReady] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -36,6 +38,7 @@ export function useCamera(): UseCameraReturn {
         }
 
         streamRef.current = stream
+        setStream(stream)
 
         if (videoRef.current) {
           videoRef.current.srcObject = stream
@@ -85,5 +88,5 @@ export function useCamera(): UseCameraReturn {
     return canvas.toDataURL('image/jpeg', 0.85)
   }, [])
 
-  return { videoRef, isReady, error, capture }
+  return { videoRef, stream, isReady, error, capture }
 }

--- a/src/hooks/use-shooting-sync.ts
+++ b/src/hooks/use-shooting-sync.ts
@@ -1,0 +1,73 @@
+'use client'
+
+import { useCallback, useEffect, useRef } from 'react'
+
+type ShootingEvent = 'shooting_start' | 'countdown' | 'shutter' | 'shooting_complete'
+
+type ShootingSyncData = {
+  readonly event: ShootingEvent
+  readonly sessionId?: string
+  readonly totalPhotos?: number
+  readonly photoIndex?: number
+  readonly count?: number
+}
+
+type UseShootingSyncOptions = {
+  readonly wsRef: React.RefObject<WebSocket | null>
+  readonly roomId: string | null
+  readonly onEvent?: (data: ShootingSyncData) => void
+}
+
+type UseShootingSyncReturn = {
+  readonly sendEvent: (data: ShootingSyncData) => void
+}
+
+export function useShootingSync({
+  wsRef,
+  roomId,
+  onEvent,
+}: UseShootingSyncOptions): UseShootingSyncReturn {
+  const onEventRef = useRef(onEvent)
+
+  useEffect(() => {
+    onEventRef.current = onEvent
+  }, [onEvent])
+
+  const sendEvent = useCallback(
+    (data: ShootingSyncData) => {
+      const ws = wsRef.current
+      if (!ws || ws.readyState !== WebSocket.OPEN || !roomId) return
+
+      ws.send(JSON.stringify({
+        action: 'shooting_sync',
+        data: { ...data, roomId },
+      }))
+    },
+    [wsRef, roomId],
+  )
+
+  useEffect(() => {
+    const ws = wsRef.current
+    if (!ws || !roomId) return
+
+    const handler = (event: MessageEvent) => {
+      try {
+        const msg = JSON.parse(event.data as string) as {
+          type: string
+          data: ShootingSyncData
+        }
+
+        if (msg.type === 'shooting_sync') {
+          onEventRef.current?.(msg.data)
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    ws.addEventListener('message', handler)
+    return () => ws.removeEventListener('message', handler)
+  }, [wsRef, roomId])
+
+  return { sendEvent }
+}

--- a/src/hooks/use-webrtc.ts
+++ b/src/hooks/use-webrtc.ts
@@ -1,0 +1,181 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+type WebRtcRole = 'phone' | 'pc'
+
+type UseWebRtcOptions = {
+  readonly wsRef: React.RefObject<WebSocket | null>
+  readonly roomId: string | null
+  readonly role: WebRtcRole
+  readonly localStream?: MediaStream | null
+}
+
+type UseWebRtcReturn = {
+  readonly remoteStream: MediaStream | null
+  readonly isConnected: boolean
+}
+
+const RTC_CONFIG: RTCConfiguration = {
+  iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+}
+
+export function useWebRtc({
+  wsRef,
+  roomId,
+  role,
+  localStream,
+}: UseWebRtcOptions): UseWebRtcReturn {
+  const pcRef = useRef<RTCPeerConnection | null>(null)
+  const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null)
+  const [isConnected, setIsConnected] = useState(false)
+
+  const sendSignaling = useCallback(
+    (action: string, data: Record<string, unknown>) => {
+      const ws = wsRef.current
+      if (!ws || ws.readyState !== WebSocket.OPEN || !roomId) return
+      ws.send(JSON.stringify({ action, data: { ...data, roomId } }))
+    },
+    [wsRef, roomId],
+  )
+
+  const createPeerConnection = useCallback(() => {
+    const pc = new RTCPeerConnection(RTC_CONFIG)
+    pcRef.current = pc
+
+    pc.onicecandidate = (event) => {
+      if (event.candidate) {
+        sendSignaling('webrtc_ice', { candidate: JSON.stringify(event.candidate) })
+      }
+    }
+
+    pc.ontrack = (event) => {
+      const stream = event.streams[0]
+      if (stream) {
+        setRemoteStream(stream)
+      }
+    }
+
+    pc.onconnectionstatechange = () => {
+      setIsConnected(pc.connectionState === 'connected')
+    }
+
+    if (localStream) {
+      localStream.getTracks().forEach((track) => {
+        pc.addTrack(track, localStream)
+      })
+    }
+
+    return pc
+  }, [localStream, sendSignaling])
+
+  const handleOffer = useCallback(
+    async (sdp: string) => {
+      const pc = createPeerConnection()
+      await pc.setRemoteDescription(new RTCSessionDescription({ type: 'offer', sdp }))
+      const answer = await pc.createAnswer()
+      await pc.setLocalDescription(answer)
+      sendSignaling('webrtc_answer', { sdp: answer.sdp })
+    },
+    [createPeerConnection, sendSignaling],
+  )
+
+  const handleAnswer = useCallback(async (sdp: string) => {
+    const pc = pcRef.current
+    if (!pc) return
+    await pc.setRemoteDescription(new RTCSessionDescription({ type: 'answer', sdp }))
+  }, [])
+
+  const handleIce = useCallback(async (candidateStr: string) => {
+    const pc = pcRef.current
+    if (!pc) return
+    try {
+      const candidate = JSON.parse(candidateStr) as RTCIceCandidateInit
+      await pc.addIceCandidate(new RTCIceCandidate(candidate))
+    } catch {
+      // ignore invalid candidates
+    }
+  }, [])
+
+  // スマホ側: オファーを送信
+  const startCall = useCallback(async () => {
+    const pc = createPeerConnection()
+    const offer = await pc.createOffer()
+    await pc.setLocalDescription(offer)
+    sendSignaling('webrtc_offer', { sdp: offer.sdp })
+  }, [createPeerConnection, sendSignaling])
+
+  // WebSocketメッセージをリッスン
+  useEffect(() => {
+    const ws = wsRef.current
+    if (!ws || !roomId) return
+
+    const handler = (event: MessageEvent) => {
+      try {
+        const msg = JSON.parse(event.data as string) as {
+          type: string
+          data: { sdp?: string; candidate?: string }
+        }
+
+        if (msg.type === 'webrtc_offer' && role === 'pc') {
+          void handleOffer(msg.data.sdp ?? '')
+        }
+        if (msg.type === 'webrtc_answer' && role === 'phone') {
+          void handleAnswer(msg.data.sdp ?? '')
+        }
+        if (msg.type === 'webrtc_ice') {
+          void handleIce(msg.data.candidate ?? '')
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    ws.addEventListener('message', handler)
+    return () => ws.removeEventListener('message', handler)
+  }, [wsRef, roomId, role, handleOffer, handleAnswer, handleIce])
+
+  // スマホ側: ルーム参加後にオファー送信
+  useEffect(() => {
+    if (role === 'phone' && roomId && localStream) {
+      const ws = wsRef.current
+      if (!ws || ws.readyState !== WebSocket.OPEN) return
+
+      // ルーム参加
+      ws.send(JSON.stringify({
+        action: 'join_room',
+        data: { roomId, role: 'phone' },
+      }))
+
+      // 少し待ってからオファー送信
+      const timer = setTimeout(() => {
+        void startCall()
+      }, 1000)
+
+      return () => clearTimeout(timer)
+    }
+  }, [role, roomId, localStream, wsRef, startCall])
+
+  // PC側: ルーム参加
+  useEffect(() => {
+    if (role === 'pc' && roomId) {
+      const ws = wsRef.current
+      if (!ws || ws.readyState !== WebSocket.OPEN) return
+
+      ws.send(JSON.stringify({
+        action: 'join_room',
+        data: { roomId, role: 'pc' },
+      }))
+    }
+  }, [role, roomId, wsRef])
+
+  // クリーンアップ
+  useEffect(() => {
+    return () => {
+      pcRef.current?.close()
+      pcRef.current = null
+    }
+  }, [])
+
+  return { remoteStream, isConnected }
+}


### PR DESCRIPTION
## Summary
- WebRTC: スマホカメラ映像をPC画面にリアルタイム配信
- shooting_sync: カウントダウン・シャッター・完了イベントをPC側に同期
- やじコメント: ニコニコ動画風にPC画面上をスライド表示

## Test plan
- [x] `npm run build` パス
- [x] `npm run lint` パス
- [ ] スマホ→PCのWebRTC映像確認
- [ ] 撮影中のカウントダウンがPC画面に表示されること
- [ ] やじコメントがスライド表示されること