### PR TITLE
fix: PC側リモート映像の自動再生

### DIFF
--- a/src/components/pc/shooting-screen.tsx
+++ b/src/components/pc/shooting-screen.tsx
@@ -26,6 +26,11 @@ export function ShootingScreen({
     const video = videoRef.current
     if (!video || !remoteStream) return
     video.srcObject = remoteStream
+    video.play().catch((err) => {
+      if (process.env.NODE_ENV === 'development') {
+        console.error('Failed to play remote video:', err)
+      }
+    })
   }, [remoteStream])
 
   return (


### PR DESCRIPTION
srcObjectセット後にplay()を明示的に呼び出し