### PR TITLE
fix: #72 #74 #69 撮影間隔+PC同期+処理進行

### DIFF
--- a/src/components/pc/pc-view.tsx
+++ b/src/components/pc/pc-view.tsx
@@ -21,6 +21,7 @@ export function PcView() {
   const wsRef = useRef<WebSocket | null>(null)
   const [countdownValue, setCountdownValue] = useState<number | null>(null)
   const [lastShutterIndex, setLastShutterIndex] = useState<number | null>(null)
+  const [pcPhotoCount, setPcPhotoCount] = useState(0)
   const initializedRef = useRef(false)
 
   // ルーム作成 + WebSocket接続（1回だけ実行）
@@ -98,16 +99,20 @@ export function PcView() {
 
   // 撮影イベント受信
   const handleShootingEvent = useCallback(
-    (data: { event: string; count?: number; photoIndex?: number }) => {
+    (data: { event: string; count?: number; photoIndex?: number; photoCount?: number }) => {
       if (data.event === 'countdown' && data.count !== undefined) {
         setCountdownValue(data.count)
       }
       if (data.event === 'shutter') {
         setCountdownValue(null)
         setLastShutterIndex(data.photoIndex ?? null)
+        if (data.photoCount !== undefined) {
+          setPcPhotoCount(data.photoCount)
+        }
       }
       if (data.event === 'shooting_start') {
         setPhase('shooting')
+        setPcPhotoCount(0)
       }
       if (data.event === 'shooting_complete') {
         setCountdownValue(null)
@@ -138,6 +143,7 @@ export function PcView() {
           countdownValue={countdownValue}
           lastShutterIndex={lastShutterIndex}
           iceState={iceState}
+          photoCount={pcPhotoCount}
         />
       )
     case 'preview':

--- a/src/components/pc/processing-screen.tsx
+++ b/src/components/pc/processing-screen.tsx
@@ -1,11 +1,54 @@
 'use client'
 
+import { useEffect, useState } from 'react'
+
 import { ProcessingSteps } from '@/components/processing/processing-steps'
 import { ReceiptFrame } from '@/components/ui/receipt-frame'
-import { useSessionStore } from '@/stores/session-store'
+import { useRoomStore } from '@/stores/room-store'
+import { useWsStore } from '@/stores/ws-store'
+
+const STEP_MAP: Record<string, string> = {
+  'face-detection': 'face-detection',
+  'filter': 'filter-apply',
+  'collage': 'collage-generate',
+  'caption': 'collage-generate',
+  'dither': 'print-prepare',
+}
 
 export function ProcessingScreen() {
-  const { processingStep } = useSessionStore()
+  const { sessionId } = useRoomStore()
+  const { ws } = useWsStore()
+  const [currentStep, setCurrentStep] = useState('uploading')
+
+  // WebSocketでstatusUpdateを受信
+  useEffect(() => {
+    if (!ws || !sessionId) return
+
+    // セッションをsubscribe
+    ws.send(JSON.stringify({
+      action: 'subscribe',
+      data: { sessionId },
+    }))
+
+    const handler = (event: MessageEvent) => {
+      try {
+        const msg = JSON.parse(event.data as string) as {
+          type: string
+          data: { step?: string }
+        }
+
+        if (msg.type === 'statusUpdate' && msg.data.step) {
+          const mapped = STEP_MAP[msg.data.step] ?? msg.data.step
+          setCurrentStep(mapped)
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    ws.addEventListener('message', handler)
+    return () => ws.removeEventListener('message', handler)
+  }, [ws, sessionId])
 
   return (
     <div className="flex min-h-dvh flex-col items-center justify-center px-8">
@@ -18,7 +61,7 @@ export function ProcessingScreen() {
         </header>
 
         <ReceiptFrame className="px-6 py-5" showTornEdge={false}>
-          <ProcessingSteps currentStep={processingStep ?? 'uploading'} />
+          <ProcessingSteps currentStep={currentStep} />
         </ReceiptFrame>
       </div>
     </div>

--- a/src/components/pc/shooting-screen.tsx
+++ b/src/components/pc/shooting-screen.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useRef } from 'react'
 
-import { useSessionStore } from '@/stores/session-store'
-
 import { YajiComment } from './yaji-comment'
 
 type ShootingScreenProps = {
@@ -12,6 +10,7 @@ type ShootingScreenProps = {
   readonly countdownValue: number | null
   readonly lastShutterIndex: number | null
   readonly iceState: string | null
+  readonly photoCount: number
 }
 
 export function ShootingScreen({
@@ -20,8 +19,8 @@ export function ShootingScreen({
   countdownValue,
   lastShutterIndex,
   iceState,
+  photoCount,
 }: ShootingScreenProps) {
-  const { photos } = useSessionStore()
   const videoRef = useRef<HTMLVideoElement>(null)
 
   useEffect(() => {
@@ -93,12 +92,12 @@ export function ShootingScreen({
             key={i}
             className={[
               'h-3 w-3 rounded-full transition-all',
-              i < photos.length ? 'bg-ink' : 'bg-cream-dark',
+              i < photoCount ? 'bg-ink' : 'bg-cream-dark',
             ].join(' ')}
           />
         ))}
         <p className="receipt-text ml-2 text-sm text-ink-light">
-          {photos.length}/4 枚撮影済み
+          {photoCount}/4 枚撮影済み
         </p>
       </div>
     </div>

--- a/src/components/shoot/shoot-view.tsx
+++ b/src/components/shoot/shoot-view.tsx
@@ -51,6 +51,7 @@ export function ShootView() {
     sendSync('shooting_start', { totalPhotos: TOTAL_PHOTOS })
 
     for (let i = photoCount; i < TOTAL_PHOTOS; i++) {
+      // カウントダウン開始をPC側に同期
       sendSync('countdown', { photoIndex: i, count: 3 })
 
       await startCountdown(3)
@@ -59,11 +60,11 @@ export function ShootView() {
       if (dataUrl) {
         addPhoto(dataUrl)
         setFlashTrigger((prev) => prev + 1)
-        sendSync('shutter', { photoIndex: i })
+        sendSync('shutter', { photoIndex: i, photoCount: i + 1 })
       }
 
       if (i < TOTAL_PHOTOS - 1) {
-        await new Promise((resolve) => setTimeout(resolve, 800))
+        await new Promise((resolve) => setTimeout(resolve, 3000))
       }
     }
 


### PR DESCRIPTION
## 修正内容
- #72: 連続撮影間隔 0.8秒→3秒
- #74: PC側カウントダウン数字+撮影枚数リアルタイム同期
- #69: PC版ProcessingScreenでWebSocket subscribe→statusUpdate受信

Closes #72 #74 #69