### PR TITLE
fix: PC側カウントダウン数字のリアルタイム同期 (#74)

### DIFF
--- a/src/components/shoot/shoot-view.tsx
+++ b/src/components/shoot/shoot-view.tsx
@@ -19,7 +19,6 @@ const TOTAL_PHOTOS = 4
 export function ShootView() {
   const router = useRouter()
   const { videoRef, isReady, error, capture, stream } = useCamera()
-  const { count, isRunning, start: startCountdown } = useCountdown()
   const { filter, addPhoto, photos } = useSessionStore()
   const { roomId } = useRoomStore()
   const { ws, send } = useWsStore()
@@ -43,6 +42,13 @@ export function ShootView() {
     },
     [roomId, send],
   )
+
+  const onCountdownTick = useCallback(
+    (value: number) => sendSync('countdown', { count: value }),
+    [sendSync],
+  )
+
+  const { count, isRunning, start: startCountdown } = useCountdown({ onTick: onCountdownTick })
 
   const shootSequence = useCallback(async () => {
     if (isShootingRef.current) return

--- a/src/hooks/use-countdown.ts
+++ b/src/hooks/use-countdown.ts
@@ -2,16 +2,25 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+type UseCountdownOptions = {
+  readonly onTick?: (value: number) => void
+}
+
 type UseCountdownReturn = {
   readonly count: number | null
   readonly isRunning: boolean
   readonly start: (from?: number) => Promise<void>
 }
 
-export function useCountdown(): UseCountdownReturn {
+export function useCountdown(options?: UseCountdownOptions): UseCountdownReturn {
   const [count, setCount] = useState<number | null>(null)
   const [isRunning, setIsRunning] = useState(false)
   const resolveRef = useRef<(() => void) | null>(null)
+  const onTickRef = useRef(options?.onTick)
+
+  useEffect(() => {
+    onTickRef.current = options?.onTick
+  }, [options?.onTick])
 
   useEffect(() => {
     if (!isRunning || count === null || count <= 0) return
@@ -25,6 +34,7 @@ export function useCountdown(): UseCountdownReturn {
         resolveRef.current = null
       } else {
         setCount(next)
+        onTickRef.current?.(next)
       }
     }, 1000)
 


### PR DESCRIPTION
## Summary
- `useCountdown` に `onTick` コールバックを追加し、カウントダウンの各ステップ(3→2→1)をWebSocket経由でPC側に送信
- 従来は `count: 3` のみ送信され、PC側でカウントダウンが一瞬表示されて即消える問題があった
- 撮影枚数の同期は既に正常動作しているため変更なし

## Changes
| ファイル | 変更 |
|---------|------|
| `use-countdown.ts` | `onTick` コールバックオプション追加 |
| `shoot-view.tsx` | `onTick` で各カウントダウン値をPC側に送信 |

## Test plan
- [ ] スマホでカウントダウン開始 → PC側で3→2→1が1秒ずつ表示されること
- [ ] 4枚撮影が正常に完了すること
- [ ] `npx tsc --noEmit` パス済み

Closes #74