### PR TITLE
fix: カウントダウン/枚数同期 - useShootingSync wsRef競合修正

### DIFF
--- a/src/components/pc/pc-view.tsx
+++ b/src/components/pc/pc-view.tsx
@@ -136,7 +136,7 @@ export function PcView() {
   )
 
   useShootingSync({
-    wsRef,
+    ws,
     roomId,
     onEvent: handleShootingEvent,
   })

--- a/src/hooks/use-shooting-sync.ts
+++ b/src/hooks/use-shooting-sync.ts
@@ -14,7 +14,7 @@ type ShootingSyncData = {
 }
 
 type UseShootingSyncOptions = {
-  readonly wsRef: React.RefObject<WebSocket | null>
+  readonly ws: WebSocket | null
   readonly roomId: string | null
   readonly onEvent?: (data: ShootingSyncData) => void
 }
@@ -24,7 +24,7 @@ type UseShootingSyncReturn = {
 }
 
 export function useShootingSync({
-  wsRef,
+  ws,
   roomId,
   onEvent,
 }: UseShootingSyncOptions): UseShootingSyncReturn {
@@ -36,7 +36,6 @@ export function useShootingSync({
 
   const sendEvent = useCallback(
     (data: ShootingSyncData) => {
-      const ws = wsRef.current
       if (!ws || ws.readyState !== WebSocket.OPEN || !roomId) return
 
       ws.send(JSON.stringify({
@@ -44,11 +43,10 @@ export function useShootingSync({
         data: { ...data, roomId },
       }))
     },
-    [wsRef, roomId],
+    [ws, roomId],
   )
 
   useEffect(() => {
-    const ws = wsRef.current
     if (!ws || !roomId) return
 
     const handler = (event: MessageEvent) => {
@@ -70,7 +68,7 @@ export function useShootingSync({
 
     ws.addEventListener('message', handler)
     return () => ws.removeEventListener('message', handler)
-  }, [wsRef, roomId])
+  }, [ws, roomId])
 
   return { sendEvent }
 }


### PR DESCRIPTION
## Summary
- `useShootingSync` の依存を `wsRef` (不変Refオブジェクト) → `ws` (実際のWebSocket値) に変更
- これにより useEffect が WebSocket 接続確立時に正しく再実行され、リスナーが接続される
- PC側のカウントダウン (3→2→1) と撮影枚数 (1/4→2/4→3/4→4/4) がリアルタイム更新される

## Root Cause
`wsRef` は React ref オブジェクトで参照が変わらないため、useEffect の依存配列に入れても再実行されない。`wsRef.current` が後から WebSocket インスタンスで更新されてもリスナーが接続されなかった。