### PR TITLE
feat: スマホ撮影画面にARフィルター追加 (Snow風)

### DIFF
--- a/src/components/shoot/phone-ar-overlay.tsx
+++ b/src/components/shoot/phone-ar-overlay.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
+
+import type { FaceLandmarker as FaceLandmarkerType } from '@mediapipe/tasks-vision'
+
+import {
+  AR_EFFECTS,
+  EFFECT_RENDERERS,
+  MEDIAPIPE_MODEL_URL,
+  MEDIAPIPE_WASM_URL,
+  type ArEffect,
+} from '@/lib/ar-effects'
+
+type PhoneArOverlayProps = {
+  readonly videoRef: React.RefObject<HTMLVideoElement | null>
+  readonly isActive: boolean
+}
+
+export type PhoneArOverlayHandle = {
+  readonly getCanvas: () => HTMLCanvasElement | null
+}
+
+export const PhoneArOverlay = forwardRef<PhoneArOverlayHandle, PhoneArOverlayProps>(
+  function PhoneArOverlay({ videoRef, isActive }, ref) {
+    const canvasRef = useRef<HTMLCanvasElement>(null)
+    const [selectedEffect, setSelectedEffect] = useState<ArEffect | null>(null)
+    const selectedEffectRef = useRef<ArEffect | null>(selectedEffect)
+    const faceLandmarkerRef = useRef<FaceLandmarkerType | null>(null)
+    const animFrameRef = useRef<number>(0)
+    const readyRef = useRef(false)
+    const lastTimestampRef = useRef(0)
+    const canvasSizeRef = useRef({ w: 0, h: 0 })
+
+    useImperativeHandle(ref, () => ({
+      getCanvas: () => canvasRef.current,
+    }))
+
+    useEffect(() => {
+      selectedEffectRef.current = selectedEffect
+    }, [selectedEffect])
+
+    // MediaPipe FaceLandmarker の初期化
+    useEffect(() => {
+      if (!isActive) return
+
+      let cancelled = false
+
+      const init = async () => {
+        try {
+          const { FaceLandmarker, FilesetResolver } = await import('@mediapipe/tasks-vision')
+          if (cancelled) return
+
+          const filesetResolver = await FilesetResolver.forVisionTasks(MEDIAPIPE_WASM_URL)
+          if (cancelled) return
+
+          const landmarker = await FaceLandmarker.createFromOptions(filesetResolver, {
+            baseOptions: {
+              modelAssetPath: MEDIAPIPE_MODEL_URL,
+              delegate: 'GPU',
+            },
+            runningMode: 'VIDEO',
+            numFaces: 2,
+          })
+
+          if (cancelled) {
+            landmarker.close()
+            return
+          }
+
+          faceLandmarkerRef.current = landmarker
+          readyRef.current = true
+        } catch (err) {
+          if (process.env.NODE_ENV === 'development') {
+            console.warn('PhoneArOverlay: MediaPipe init failed:', err)
+          }
+        }
+      }
+
+      void init()
+
+      return () => {
+        cancelled = true
+        readyRef.current = false
+        if (faceLandmarkerRef.current) {
+          faceLandmarkerRef.current.close()
+          faceLandmarkerRef.current = null
+        }
+      }
+    }, [isActive])
+
+    // フレーム描画ループ
+    useEffect(() => {
+      if (!isActive) return
+
+      const render = () => {
+        const video = videoRef.current
+        const canvas = canvasRef.current
+        const faceLandmarker = faceLandmarkerRef.current
+        const effect = selectedEffectRef.current
+
+        if (video && canvas && readyRef.current && faceLandmarker && effect && video.readyState >= 2) {
+          const vw = video.videoWidth || video.clientWidth
+          const vh = video.videoHeight || video.clientHeight
+
+          if (canvasSizeRef.current.w !== vw || canvasSizeRef.current.h !== vh) {
+            canvas.width = vw
+            canvas.height = vh
+            canvasSizeRef.current = { w: vw, h: vh }
+          }
+
+          const ctx = canvas.getContext('2d')
+          if (ctx) {
+            ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+            try {
+              const now = performance.now()
+              const timestamp = now > lastTimestampRef.current ? now : lastTimestampRef.current + 1
+              lastTimestampRef.current = timestamp
+
+              const result = faceLandmarker.detectForVideo(video, timestamp)
+
+              for (const landmarks of result.faceLandmarks) {
+                const renderer = EFFECT_RENDERERS[effect]
+                renderer(ctx, landmarks, canvas.width, canvas.height)
+              }
+            } catch {
+              // 検出エラーは無視
+            }
+          }
+        } else if (canvas && !effect) {
+          const ctx = canvas.getContext('2d')
+          if (ctx) {
+            ctx.clearRect(0, 0, canvas.width, canvas.height)
+          }
+        }
+
+        animFrameRef.current = requestAnimationFrame(render)
+      }
+
+      animFrameRef.current = requestAnimationFrame(render)
+
+      return () => {
+        cancelAnimationFrame(animFrameRef.current)
+      }
+    }, [isActive, videoRef])
+
+    if (!isActive) return null
+
+    return (
+      <>
+        <canvas
+          ref={canvasRef}
+          className="pointer-events-none absolute inset-0 h-full w-full"
+          style={{ transform: 'scaleX(-1)' }}
+        />
+
+        <div className="absolute top-4 left-1/2 z-10 flex -translate-x-1/2 gap-1.5">
+          <button
+            type="button"
+            onClick={() => setSelectedEffect(null)}
+            className={[
+              'rounded-full px-2.5 py-1 text-[11px] font-bold transition-colors',
+              selectedEffect === null
+                ? 'bg-white text-ink'
+                : 'bg-ink/40 text-white/70 active:bg-ink/60',
+            ].join(' ')}
+          >
+            なし
+          </button>
+          {AR_EFFECTS.map((effect) => (
+            <button
+              key={effect.id}
+              type="button"
+              onClick={() => setSelectedEffect(effect.id)}
+              className={[
+                'rounded-full px-2.5 py-1 text-[11px] font-bold transition-colors',
+                selectedEffect === effect.id
+                  ? 'bg-pink text-white'
+                  : 'bg-ink/40 text-white/70 active:bg-ink/60',
+              ].join(' ')}
+            >
+              {effect.label}
+            </button>
+          ))}
+        </div>
+      </>
+    )
+  },
+)

--- a/src/components/shoot/shoot-view.tsx
+++ b/src/components/shoot/shoot-view.tsx
@@ -3,6 +3,8 @@
 import { useRouter } from 'next/navigation'
 import { useCallback, useRef, useState } from 'react'
 
+import type { PhoneArOverlayHandle } from './phone-ar-overlay'
+
 import { StepIndicator } from '@/components/ui/step-indicator'
 import { useCamera } from '@/hooks/use-camera'
 import { useCountdown } from '@/hooks/use-countdown'
@@ -17,12 +19,14 @@ import { useWsStore } from '@/stores/ws-store'
 
 import { CountdownOverlay } from './countdown-overlay'
 import { FlashOverlay } from './flash-overlay'
+import { PhoneArOverlay } from './phone-ar-overlay'
 
 const TOTAL_PHOTOS = 4
 
 export function ShootView() {
   const router = useRouter()
-  const { videoRef, isReady, error, capture, stream } = useCamera()
+  const { videoRef, isReady, error, capture, captureWithOverlay, stream } = useCamera()
+  const arOverlayRef = useRef<PhoneArOverlayHandle>(null)
   const { filter, addPhoto, photos, startSession } = useSessionStore()
   const { roomId, setSessionId } = useRoomStore()
   const { ws, send } = useWsStore()
@@ -93,7 +97,8 @@ export function ShootView() {
 
       await startCountdown(3)
 
-      const dataUrl = capture()
+      const overlayCanvas = arOverlayRef.current?.getCanvas() ?? null
+      const dataUrl = captureWithOverlay(overlayCanvas) ?? capture()
       if (dataUrl) {
         addPhoto(dataUrl)
         setFlashTrigger((prev) => prev + 1)
@@ -109,7 +114,7 @@ export function ShootView() {
     sendSync('shooting_complete')
     isShootingRef.current = false
     router.push('/preview')
-  }, [photoCount, startCountdown, capture, addPhoto, router, sendSync, filter, setSessionId, startSession])
+  }, [photoCount, startCountdown, capture, captureWithOverlay, addPhoto, router, sendSync, filter, setSessionId, startSession])
 
   // 音声コマンドで撮影開始（「撮って」「チーズ」等）
   const { isSupported: voiceSupported } = useVoiceCommand({
@@ -148,6 +153,7 @@ export function ShootView() {
           muted
           style={{ transform: 'scaleX(-1)' }}
         />
+        <PhoneArOverlay ref={arOverlayRef} videoRef={videoRef} isActive={isReady} />
         <CountdownOverlay count={count} />
         <FlashOverlay trigger={flashTrigger} />
       </div>

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -8,6 +8,7 @@ type UseCameraReturn = {
   readonly isReady: boolean
   readonly error: string | null
   readonly capture: () => string | null
+  readonly captureWithOverlay: (overlayCanvas: HTMLCanvasElement | null) => string | null
 }
 
 export function useCamera(): UseCameraReturn {
@@ -90,5 +91,36 @@ export function useCamera(): UseCameraReturn {
     return canvas.toDataURL('image/jpeg', 0.85)
   }, [])
 
-  return { videoRef, stream, isReady, error, capture }
+  const captureWithOverlay = useCallback(
+    (overlayCanvas: HTMLCanvasElement | null): string | null => {
+      const video = videoRef.current
+      if (!video) return null
+
+      if (!canvasRef.current) {
+        canvasRef.current = document.createElement('canvas')
+      }
+      const canvas = canvasRef.current
+      canvas.width = video.videoWidth
+      canvas.height = video.videoHeight
+
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return null
+
+      // ミラー反転してカメラ映像を描画
+      ctx.translate(canvas.width, 0)
+      ctx.scale(-1, 1)
+      ctx.drawImage(video, 0, 0)
+      ctx.setTransform(1, 0, 0, 1, 0, 0)
+
+      // AR オーバーレイを合成（オーバーレイキャンバスがあれば）
+      if (overlayCanvas && overlayCanvas.width > 0 && overlayCanvas.height > 0) {
+        ctx.drawImage(overlayCanvas, 0, 0, canvas.width, canvas.height)
+      }
+
+      return canvas.toDataURL('image/jpeg', 0.85)
+    },
+    [],
+  )
+
+  return { videoRef, stream, isReady, error, capture, captureWithOverlay }
 }

--- a/src/lib/ar-effects.ts
+++ b/src/lib/ar-effects.ts
@@ -1,0 +1,155 @@
+/**
+ * Shared AR effect drawing functions used by both PC and phone overlays.
+ */
+
+export type ArEffect = 'dog' | 'cat' | 'sparkle' | 'crown' | 'heart'
+
+export type FaceLandmark = {
+  readonly x: number
+  readonly y: number
+  readonly z: number
+}
+
+export const AR_EFFECTS: readonly { readonly id: ArEffect; readonly label: string }[] = [
+  { id: 'dog', label: '犬' },
+  { id: 'cat', label: '猫' },
+  { id: 'sparkle', label: 'キラキラ' },
+  { id: 'crown', label: '王冠' },
+  { id: 'heart', label: 'ハート' },
+]
+
+// CDN version pinned to installed package version
+export const MEDIAPIPE_WASM_URL = 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.32/wasm'
+
+export const MEDIAPIPE_MODEL_URL =
+  'https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/1/face_landmarker.task'
+
+// MediaPipe Face Mesh key landmark indices
+const NOSE_TIP = 1
+const LEFT_EYE = 159
+const RIGHT_EYE = 386
+const FOREHEAD = 10
+const LEFT_CHEEK = 234
+const RIGHT_CHEEK = 454
+
+function drawDogEars(
+  ctx: CanvasRenderingContext2D,
+  landmarks: readonly FaceLandmark[],
+  w: number,
+  h: number,
+): void {
+  const forehead = landmarks[FOREHEAD]
+  const leftEye = landmarks[LEFT_EYE]
+  const rightEye = landmarks[RIGHT_EYE]
+  const nose = landmarks[NOSE_TIP]
+  if (!forehead || !leftEye || !rightEye || !nose) return
+
+  const eyeDistance = Math.abs(rightEye.x - leftEye.x) * w
+  const earSize = eyeDistance * 0.6
+
+  ctx.font = `${earSize}px serif`
+  ctx.textAlign = 'center'
+  ctx.fillText('🐕', leftEye.x * w - earSize * 0.3, forehead.y * h - earSize * 0.3)
+  ctx.fillText('🐕', rightEye.x * w + earSize * 0.3, forehead.y * h - earSize * 0.3)
+  ctx.font = `${earSize * 0.5}px serif`
+  ctx.fillText('🐽', nose.x * w, nose.y * h + earSize * 0.1)
+}
+
+function drawCatEars(
+  ctx: CanvasRenderingContext2D,
+  landmarks: readonly FaceLandmark[],
+  w: number,
+  h: number,
+): void {
+  const forehead = landmarks[FOREHEAD]
+  const leftEye = landmarks[LEFT_EYE]
+  const rightEye = landmarks[RIGHT_EYE]
+  if (!forehead || !leftEye || !rightEye) return
+
+  const eyeDistance = Math.abs(rightEye.x - leftEye.x) * w
+  const earSize = eyeDistance * 0.7
+
+  ctx.font = `${earSize}px serif`
+  ctx.textAlign = 'center'
+  ctx.fillText('😺', ((leftEye.x + rightEye.x) / 2) * w, forehead.y * h - earSize * 0.5)
+}
+
+function drawSparkles(
+  ctx: CanvasRenderingContext2D,
+  landmarks: readonly FaceLandmark[],
+  w: number,
+  h: number,
+): void {
+  const leftEye = landmarks[LEFT_EYE]
+  const rightEye = landmarks[RIGHT_EYE]
+  if (!leftEye || !rightEye) return
+
+  const eyeDistance = Math.abs(rightEye.x - leftEye.x) * w
+  const size = eyeDistance * 0.3
+
+  ctx.font = `${size}px serif`
+  ctx.textAlign = 'center'
+
+  const time = Date.now() / 500
+  const offsets = [
+    { dx: -0.3, dy: -0.2 },
+    { dx: 0.3, dy: -0.1 },
+    { dx: -0.4, dy: 0.1 },
+    { dx: 0.4, dy: 0 },
+  ]
+
+  for (const { dx, dy } of offsets) {
+    const wobble = Math.sin(time + dx * 10) * size * 0.1
+    ctx.fillText('✨', leftEye.x * w + dx * eyeDistance + wobble, leftEye.y * h + dy * eyeDistance)
+    ctx.fillText('✨', rightEye.x * w + dx * eyeDistance + wobble, rightEye.y * h + dy * eyeDistance)
+  }
+}
+
+function drawCrown(
+  ctx: CanvasRenderingContext2D,
+  landmarks: readonly FaceLandmark[],
+  w: number,
+  h: number,
+): void {
+  const forehead = landmarks[FOREHEAD]
+  const leftEye = landmarks[LEFT_EYE]
+  const rightEye = landmarks[RIGHT_EYE]
+  if (!forehead || !leftEye || !rightEye) return
+
+  const eyeDistance = Math.abs(rightEye.x - leftEye.x) * w
+  const size = eyeDistance * 0.8
+
+  ctx.font = `${size}px serif`
+  ctx.textAlign = 'center'
+  ctx.fillText('👑', ((leftEye.x + rightEye.x) / 2) * w, forehead.y * h - size * 0.3)
+}
+
+function drawHearts(
+  ctx: CanvasRenderingContext2D,
+  landmarks: readonly FaceLandmark[],
+  w: number,
+  h: number,
+): void {
+  const leftCheek = landmarks[LEFT_CHEEK]
+  const rightCheek = landmarks[RIGHT_CHEEK]
+  if (!leftCheek || !rightCheek) return
+
+  const cheekDistance = Math.abs(rightCheek.x - leftCheek.x) * w
+  const size = cheekDistance * 0.15
+
+  ctx.font = `${size}px serif`
+  ctx.textAlign = 'center'
+  ctx.fillText('💕', leftCheek.x * w, leftCheek.y * h)
+  ctx.fillText('💕', rightCheek.x * w, rightCheek.y * h)
+}
+
+export const EFFECT_RENDERERS: Record<
+  ArEffect,
+  (ctx: CanvasRenderingContext2D, landmarks: readonly FaceLandmark[], w: number, h: number) => void
+> = {
+  dog: drawDogEars,
+  cat: drawCatEars,
+  sparkle: drawSparkles,
+  crown: drawCrown,
+  heart: drawHearts,
+}


### PR DESCRIPTION
## Summary
- スマホのカメラ映像にMediaPipe Face MeshベースのリアルタイムARフィルターを追加
- 撮影時にARオーバーレイを合成してキャプチャ（Snow風）
- AR描画ロジックをPC/スマホ共通モジュールに抽出

## Changes
| ファイル | 変更 |
|---------|------|
| `lib/ar-effects.ts` | 新規: 共通AR描画モジュール (5エフェクト) |
| `shoot/phone-ar-overlay.tsx` | 新規: スマホ用ARオーバーレイ (forwardRef) |
| `hooks/use-camera.ts` | `captureWithOverlay()` メソッド追加 |
| `shoot/shoot-view.tsx` | PhoneArOverlay統合、AR合成キャプチャ |